### PR TITLE
Update ITAR references to broader export control

### DIFF
--- a/AirGap/AirGap.manifest
+++ b/AirGap/AirGap.manifest
@@ -4,7 +4,7 @@
     "id": "airgap-f360-itar-compliance-00001",
     "author": "Infab",
     "description": {
-        "": "ITAR compliance workflow enforcement. Forces offline mode, blocks cloud saves, enables local-only file export."
+        "": "Export control workflow safeguards. Forces offline mode, blocks cloud saves, enables local-only file export."
     },
     "version": "1.0.0",
     "runOnStartup": true,

--- a/AirGap/AirGap.py
+++ b/AirGap/AirGap.py
@@ -231,7 +231,9 @@ class _AutoStartHandler(adsk.core.CustomEventHandler):
             logger = AuditLogger.instance()
             session.start_session(session_id, export_dir, start_time)
             logger.start_session_log(session_id)
-            logger.log("SESSION_AUTO_START", f"AirGap session auto-started. Export dir: {export_dir}")
+            logger.log(
+                "SESSION_AUTO_START", f"AirGap session auto-started. Export dir: {export_dir}"
+            )
 
             enforcer = get_enforcer()
             if not enforcer.activate(app, retries=5):

--- a/AirGap/AirGap.py
+++ b/AirGap/AirGap.py
@@ -15,7 +15,7 @@ from AirGap.commands.start_session import get_enforcer, get_interceptor
 from AirGap.lib import ui_components
 from AirGap.lib.audit_logger import AuditLogger
 from AirGap.lib.persistence import SessionPersistence
-from AirGap.lib.session_manager import ITARSessionManager, SessionState
+from AirGap.lib.session_manager import SessionManager, SessionState
 from AirGap.lib.settings import Settings
 
 _app = None
@@ -46,7 +46,7 @@ def run(context):
 def stop(context):
     global _auto_start_event
     try:
-        session = ITARSessionManager.instance()
+        session = SessionManager.instance()
         if session.is_protected:
             SessionPersistence.save_state(session)
             AuditLogger.instance().log(
@@ -97,19 +97,19 @@ def _handle_crash_recovery(app: adsk.core.Application, ui: adsk.core.UserInterfa
     exported_count = len(saved_state.get("exported_documents", []))
 
     result = ui.messageBox(
-        "AirGap detected an unclean shutdown while an ITAR session "
+        "AirGap detected an unclean shutdown while an AirGap session "
         "was active.\n\n"
         f"Previous session had {tracked_count} tracked document(s), "
         f"{exported_count} exported.\n\n"
         "Fusion has been placed in offline mode as a precaution.\n\n"
-        "Would you like to restore the ITAR session?",
+        "Would you like to restore the AirGap session?",
         "AirGap - Crash Recovery",
         adsk.core.MessageBoxButtonTypes.YesNoButtonType,
         adsk.core.MessageBoxIconTypes.WarningIconType,
     )
 
     if result == adsk.core.DialogResults.DialogYes:
-        session = ITARSessionManager.instance()
+        session = SessionManager.instance()
         SessionPersistence.restore_session(session, saved_state)
 
         enforcer = get_enforcer()
@@ -125,7 +125,7 @@ def _handle_crash_recovery(app: adsk.core.Application, ui: adsk.core.UserInterfa
         ui.messageBox(
             "Session not restored. Fusion remains offline.\n\n"
             "You may manually go online when you are confident "
-            "no ITAR data is present.",
+            "no export-controlled data is present.",
             "AirGap",
             adsk.core.MessageBoxButtonTypes.OKButtonType,
             adsk.core.MessageBoxIconTypes.InformationIconType,
@@ -135,7 +135,7 @@ def _handle_crash_recovery(app: adsk.core.Application, ui: adsk.core.UserInterfa
 def _schedule_auto_start(app: adsk.core.Application):
     global _auto_start_event
 
-    session = ITARSessionManager.instance()
+    session = SessionManager.instance()
     if session.is_protected:
         return
 
@@ -199,7 +199,7 @@ class _AutoStartHandler(adsk.core.CustomEventHandler):
         try:
             app = adsk.core.Application.get()
             ui = app.userInterface
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
 
             if session.is_protected:
                 return
@@ -231,7 +231,7 @@ class _AutoStartHandler(adsk.core.CustomEventHandler):
             logger = AuditLogger.instance()
             session.start_session(session_id, export_dir, start_time)
             logger.start_session_log(session_id)
-            logger.log("SESSION_AUTO_START", f"ITAR session auto-started. Export dir: {export_dir}")
+            logger.log("SESSION_AUTO_START", f"AirGap session auto-started. Export dir: {export_dir}")
 
             enforcer = get_enforcer()
             if not enforcer.activate(app, retries=5):
@@ -243,7 +243,7 @@ class _AutoStartHandler(adsk.core.CustomEventHandler):
                 logger.end_session_log()
                 ui.messageBox(
                     "AirGap auto-start failed: could not enable offline mode.\n\n"
-                    "Please start the ITAR session manually.",
+                    "Please start the AirGap session manually.",
                     "AirGap - Error",
                     adsk.core.MessageBoxButtonTypes.OKButtonType,
                     adsk.core.MessageBoxIconTypes.CriticalIconType,
@@ -263,7 +263,7 @@ class _AutoStartHandler(adsk.core.CustomEventHandler):
             ui_components.update_button_visibility(SessionState.PROTECTED)
 
             ui.messageBox(
-                "ITAR SESSION AUTO-STARTED\n\n"
+                "AIRGAP SESSION AUTO-STARTED\n\n"
                 f"Session ID: {session_id}\n"
                 f"Export Directory: {export_dir}\n\n"
                 "Fusion is offline and cloud saves are blocked.\n\n"

--- a/AirGap/commands/__init__.py
+++ b/AirGap/commands/__init__.py
@@ -16,15 +16,15 @@ def register_commands(ui: adsk.core.UserInterface):
     commands = [
         (
             config.CMD_START_SESSION,
-            "Start ITAR Session",
-            "Activate ITAR compliance mode. Forces offline, blocks cloud saves.",
+            "Start AirGap Session",
+            "Start an AirGap session. Forces offline, blocks cloud saves.",
             config.ICON_AIRGAP_OFF,
             StartSessionCommand,
         ),
         (
             config.CMD_STOP_SESSION,
-            "Stop ITAR Session",
-            "Deactivate ITAR session. Requires all docs exported and closed.",
+            "Stop AirGap Session",
+            "End the AirGap session. Requires all docs exported and closed.",
             config.ICON_AIRGAP_ON,
             StopSessionCommand,
         ),
@@ -38,7 +38,7 @@ def register_commands(ui: adsk.core.UserInterface):
         (
             config.CMD_VIEW_LOG,
             "View Audit Log",
-            "Open the ITAR compliance audit log.",
+            "Open the AirGap audit log.",
             "",
             ViewLogCommand,
         ),

--- a/AirGap/commands/export_local.py
+++ b/AirGap/commands/export_local.py
@@ -7,7 +7,7 @@ import adsk.fusion
 
 from AirGap.lib.audit_logger import AuditLogger
 from AirGap.lib.export_manager import LocalExportManager
-from AirGap.lib.session_manager import ITARSessionManager
+from AirGap.lib.session_manager import SessionManager
 
 _handlers = []
 
@@ -20,7 +20,7 @@ class ExportLocalCommand(adsk.core.CommandCreatedEventHandler):
         try:
             cmd = args.command
             inputs = cmd.commandInputs
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
             app = adsk.core.Application.get()
 
             inputs.addStringValueInput("exportDir", "Export Directory", session.export_directory)
@@ -131,7 +131,7 @@ class ExportExecuteHandler(adsk.core.CommandEventHandler):
             app = adsk.core.Application.get()
             ui = app.userInterface
             inputs = args.command.commandInputs
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
 
             export_dir = Path(inputs.itemById("exportDir").value.strip())
             export_dir.mkdir(parents=True, exist_ok=True)

--- a/AirGap/commands/settings.py
+++ b/AirGap/commands/settings.py
@@ -29,7 +29,7 @@ class SettingsCommand(adsk.core.CommandCreatedEventHandler):
 
             inputs.addBoolValueInput(
                 "autoSession",
-                "Auto-start ITAR session on Fusion startup",
+                "Auto-start AirGap session on Fusion startup",
                 True,
                 "",
                 settings.auto_start_session,

--- a/AirGap/commands/start_session.py
+++ b/AirGap/commands/start_session.py
@@ -8,7 +8,7 @@ from AirGap.lib.audit_logger import AuditLogger
 from AirGap.lib.offline_enforcer import OfflineEnforcer
 from AirGap.lib.persistence import SessionPersistence
 from AirGap.lib.save_interceptor import SaveInterceptor
-from AirGap.lib.session_manager import ITARSessionManager, SessionState, is_default_document
+from AirGap.lib.session_manager import SessionManager, SessionState, is_default_document
 from AirGap.lib.settings import Settings
 from AirGap.lib.ui_components import update_button_visibility
 
@@ -43,7 +43,7 @@ class StartSessionCommand(adsk.core.CommandCreatedEventHandler):
             inputs.addBoolValueInput(
                 "confirmItar",
                 "I understand all documents opened during "
-                "this session will be treated as ITAR-controlled",
+                "this session will be treated as export-controlled",
                 True,
                 "",
                 False,
@@ -128,12 +128,12 @@ class StartSessionExecuteHandler(adsk.core.CommandEventHandler):
             export_path = Path(export_dir)
             export_path.mkdir(parents=True, exist_ok=True)
 
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
             logger = AuditLogger.instance()
 
             if not session.transition_to(SessionState.ACTIVATING):
                 ui.messageBox(
-                    "Cannot start ITAR session: invalid state transition.", "AirGap - Error"
+                    "Cannot start AirGap session: invalid state transition.", "AirGap - Error"
                 )
                 return
 
@@ -141,7 +141,7 @@ class StartSessionExecuteHandler(adsk.core.CommandEventHandler):
             start_time = datetime.datetime.now().isoformat()
             session.start_session(session_id, export_dir, start_time)
             logger.start_session_log(session_id)
-            logger.log("SESSION_START", f"ITAR session initiated. Export dir: {export_dir}")
+            logger.log("SESSION_START", f"AirGap session initiated. Export dir: {export_dir}")
 
             if not _enforcer.activate(app):
                 logger.log("SESSION_ABORT", "Could not enable offline mode", "CRITICAL")
@@ -149,7 +149,7 @@ class StartSessionExecuteHandler(adsk.core.CommandEventHandler):
                 session.reset()
                 logger.end_session_log()
                 ui.messageBox(
-                    "FAILED TO START ITAR SESSION\n\n"
+                    "FAILED TO START AIRGAP SESSION\n\n"
                     "Could not enable offline mode. Fusion may not support "
                     "programmatic offline control in this version.\n\n"
                     "Please manually enable offline mode and try again.",
@@ -179,7 +179,7 @@ class StartSessionExecuteHandler(adsk.core.CommandEventHandler):
                     logger.log("DOC_OPENED", f"Active document tracked: {doc_name}")
 
             ui.messageBox(
-                "ITAR SESSION ACTIVE\n\n"
+                "AIRGAP SESSION ACTIVE\n\n"
                 f"Session ID: {session_id}\n"
                 f"Export Directory: {export_dir}\n\n"
                 "- Fusion is now OFFLINE\n"

--- a/AirGap/commands/stop_session.py
+++ b/AirGap/commands/stop_session.py
@@ -5,7 +5,7 @@ import adsk.core
 from AirGap.commands.start_session import get_enforcer, get_interceptor
 from AirGap.lib.audit_logger import AuditLogger
 from AirGap.lib.persistence import SessionPersistence
-from AirGap.lib.session_manager import ITARSessionManager, SessionState
+from AirGap.lib.session_manager import SessionManager, SessionState
 from AirGap.lib.ui_components import update_button_visibility
 
 _handlers = []
@@ -19,7 +19,7 @@ class StopSessionCommand(adsk.core.CommandCreatedEventHandler):
         try:
             cmd = args.command
             inputs = cmd.commandInputs
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
 
             tracked = session.tracked_documents
             exported = session.exported_documents
@@ -45,14 +45,14 @@ class StopSessionCommand(adsk.core.CommandCreatedEventHandler):
                     "WARNING",
                     f'<b style="color:red">{len(unexported)} document(s) have NOT been '
                     f"exported locally. You must export all documents before ending "
-                    f"the ITAR session.</b>",
+                    f"the AirGap session.</b>",
                     3,
                     True,
                 )
 
             inputs.addBoolValueInput(
                 "confirmExport",
-                "I confirm all ITAR data has been exported and no ITAR documents remain open",
+                "I confirm all export-controlled data has been exported and no protected documents remain open",
                 True,
                 "",
                 False,
@@ -88,7 +88,7 @@ class StopSessionValidateHandler(adsk.core.ValidateInputsEventHandler):
     def notify(self, args):
         try:
             inputs = args.inputs
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
 
             confirm_export = inputs.itemById("confirmExport")
             confirm_cache = inputs.itemById("confirmCache")
@@ -124,7 +124,7 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
         try:
             app = adsk.core.Application.get()
             ui = app.userInterface
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
             logger = AuditLogger.instance()
 
             if not session.transition_to(SessionState.DEACTIVATING):
@@ -148,7 +148,7 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
                 )
                 return
 
-            logger.log("SESSION_END", "ITAR session ended cleanly")
+            logger.log("SESSION_END", "AirGap session ended cleanly")
 
             get_enforcer().deactivate()
             get_interceptor().deactivate()
@@ -161,12 +161,12 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
             update_button_visibility(SessionState.UNPROTECTED)
 
             ui.messageBox(
-                "ITAR SESSION ENDED\n\n"
+                "AIRGAP SESSION ENDED\n\n"
                 "Offline enforcement and save blocking have been deactivated.\n\n"
                 "IMPORTANT: Fusion is still in offline mode. You must "
-                "manually go online when you are confident no ITAR data "
+                "manually go online when you are confident no export-controlled data "
                 "remains in Fusion's local cache.\n\n"
-                "Refer to the ITAR Compliance Guide for cache clearing "
+                "Refer to the compliance guide for cache clearing "
                 "procedures.",
                 "AirGap - Session Ended",
                 adsk.core.MessageBoxButtonTypes.OKButtonType,

--- a/AirGap/commands/view_log.py
+++ b/AirGap/commands/view_log.py
@@ -42,7 +42,7 @@ class ViewLogExecuteHandler(adsk.core.CommandEventHandler):
                 if not log_path.exists():
                     app = adsk.core.Application.get()
                     app.userInterface.messageBox(
-                        "No audit logs found.\n\nStart an ITAR session to begin logging.",
+                        "No audit logs found.\n\nStart an AirGap session to begin logging.",
                         "AirGap - Audit Log",
                     )
                     return

--- a/AirGap/lib/offline_enforcer.py
+++ b/AirGap/lib/offline_enforcer.py
@@ -5,7 +5,7 @@ import adsk.core
 
 import AirGap.config as config
 from AirGap.lib.audit_logger import AuditLogger
-from AirGap.lib.session_manager import ITARSessionManager
+from AirGap.lib.session_manager import SessionManager
 
 
 class OnlineStatusChangedHandler(adsk.core.ApplicationEventHandler):
@@ -14,7 +14,7 @@ class OnlineStatusChangedHandler(adsk.core.ApplicationEventHandler):
 
     def notify(self, args):
         try:
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
             if not session.is_protected:
                 return
             app = adsk.core.Application.get()
@@ -27,9 +27,9 @@ class OnlineStatusChangedHandler(adsk.core.ApplicationEventHandler):
                 )
                 ui = app.userInterface
                 ui.messageBox(
-                    "ITAR SESSION ACTIVE\n\n"
+                    "AIRGAP SESSION ACTIVE\n\n"
                     "Online mode was blocked. Fusion must remain offline "
-                    "during ITAR-protected sessions.\n\n"
+                    "during active AirGap sessions.\n\n"
                     'Use "Export Locally" to save your work.',
                     "AirGap - Warning",
                     adsk.core.MessageBoxButtonTypes.OKButtonType,
@@ -49,7 +49,7 @@ class OfflineViolationCustomHandler(adsk.core.CustomEventHandler):
             data = json.loads(event_args.additionalInfo)
             if not data.get("violation"):
                 return
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
             if not session.is_protected:
                 return
             app = adsk.core.Application.get()
@@ -62,9 +62,9 @@ class OfflineViolationCustomHandler(adsk.core.CustomEventHandler):
                 )
                 ui = app.userInterface
                 ui.messageBox(
-                    "ITAR SESSION ACTIVE\n\n"
+                    "AIRGAP SESSION ACTIVE\n\n"
                     "Online mode was blocked. Fusion must remain offline "
-                    "during ITAR-protected sessions.",
+                    "during active AirGap sessions.",
                     "AirGap - Warning",
                     adsk.core.MessageBoxButtonTypes.OKButtonType,
                     adsk.core.MessageBoxIconTypes.WarningIconType,
@@ -82,7 +82,7 @@ class OfflineMonitorThread(threading.Thread):
 
     def run(self):
         while not self._stop_event.wait(config.OFFLINE_CHECK_INTERVAL):
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
             if not session.is_protected:
                 continue
             try:

--- a/AirGap/lib/persistence.py
+++ b/AirGap/lib/persistence.py
@@ -4,12 +4,12 @@ import os
 from pathlib import Path
 
 import AirGap.config as config
-from AirGap.lib.session_manager import ITARSessionManager, SessionState
+from AirGap.lib.session_manager import SessionManager, SessionState
 
 
 class SessionPersistence:
     @staticmethod
-    def save_state(session: ITARSessionManager):
+    def save_state(session: SessionManager):
         state_data = {
             "state": session.state.value,
             "session_id": session.session_id,
@@ -47,7 +47,7 @@ class SessionPersistence:
                 pass
 
     @staticmethod
-    def restore_session(session: ITARSessionManager, state_data: dict):
+    def restore_session(session: SessionManager, state_data: dict):
         session._state = SessionState.PROTECTED
         session._session_id = state_data.get("session_id", "")
         session._tracked_documents = set(state_data.get("tracked_documents", []))

--- a/AirGap/lib/save_interceptor.py
+++ b/AirGap/lib/save_interceptor.py
@@ -1,7 +1,7 @@
 import adsk.core
 
 from AirGap.lib.audit_logger import AuditLogger
-from AirGap.lib.session_manager import ITARSessionManager
+from AirGap.lib.session_manager import SessionManager
 
 
 class DocumentSavingHandler(adsk.core.DocumentEventHandler):
@@ -11,7 +11,7 @@ class DocumentSavingHandler(adsk.core.DocumentEventHandler):
     def notify(self, args):
         try:
             event_args = adsk.core.DocumentEventArgs.cast(args)
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
             if not session.is_protected:
                 return
 
@@ -26,7 +26,7 @@ class DocumentSavingHandler(adsk.core.DocumentEventHandler):
             ui.messageBox(
                 f"CLOUD SAVE BLOCKED\n\n"
                 f"Document: {doc_name}\n\n"
-                f"Cloud saves are prohibited during ITAR sessions.\n"
+                f"Cloud saves are blocked during AirGap sessions.\n"
                 f'Use the AirGap "Export Locally" button to save '
                 f"files to your local or NAS storage.",
                 "AirGap - Save Blocked",
@@ -44,7 +44,7 @@ class DocumentOpenedHandler(adsk.core.DocumentEventHandler):
     def notify(self, args):
         try:
             event_args = adsk.core.DocumentEventArgs.cast(args)
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
             if not session.is_protected:
                 return
             if event_args.document:
@@ -62,7 +62,7 @@ class DocumentCreatedHandler(adsk.core.DocumentEventHandler):
     def notify(self, args):
         try:
             event_args = adsk.core.DocumentEventArgs.cast(args)
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
             if not session.is_protected:
                 return
             if event_args.document:
@@ -80,7 +80,7 @@ class DocumentClosedHandler(adsk.core.DocumentEventHandler):
     def notify(self, args):
         try:
             event_args = adsk.core.DocumentEventArgs.cast(args)
-            session = ITARSessionManager.instance()
+            session = SessionManager.instance()
             if not session.is_protected:
                 return
             doc_name = event_args.document.name if event_args.document else "Unknown"

--- a/AirGap/lib/session_manager.py
+++ b/AirGap/lib/session_manager.py
@@ -22,8 +22,8 @@ _VALID_TRANSITIONS = {
 }
 
 
-class ITARSessionManager:
-    _instance: Optional["ITARSessionManager"] = None
+class SessionManager:
+    _instance: Optional["SessionManager"] = None
 
     def __init__(self):
         self._state: SessionState = SessionState.UNPROTECTED
@@ -34,7 +34,7 @@ class ITARSessionManager:
         self._session_id: str = ""
 
     @classmethod
-    def instance(cls) -> "ITARSessionManager":
+    def instance(cls) -> "SessionManager":
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance

--- a/AirGap/lib/ui_components.py
+++ b/AirGap/lib/ui_components.py
@@ -4,7 +4,7 @@ import adsk.core
 import adsk.fusion
 
 import AirGap.config as config
-from AirGap.lib.session_manager import ITARSessionManager, SessionState
+from AirGap.lib.session_manager import SessionManager, SessionState
 
 _panels_created = []
 _tabs_created = []
@@ -29,7 +29,7 @@ def create_ui(app: adsk.core.Application):
 
         panel = tab.toolbarPanels.itemById(config.TOOLBAR_PANEL_ID)
         if panel is None:
-            panel = tab.toolbarPanels.add(config.TOOLBAR_PANEL_ID, "ITAR Compliance")
+            panel = tab.toolbarPanels.add(config.TOOLBAR_PANEL_ID, "Export Control")
             _panels_created.append(panel)
 
         cmd_ids = [
@@ -47,7 +47,7 @@ def create_ui(app: adsk.core.Application):
                 ctrl = panel.controls.addCommand(cmd_def)
                 ctrl.isVisible = True
 
-    update_button_visibility(ITARSessionManager.instance().state)
+    update_button_visibility(SessionManager.instance().state)
 
 
 def destroy_ui(app: adsk.core.Application):


### PR DESCRIPTION
Refactor session manager and rebrand UI/messages. Rename ITARSessionManager to SessionManager and update all imports/usages across the codebase. Adjust SessionPersistence type hints and restore logic to use SessionManager. Replace ITAR-specific wording with AirGap / export-control phrasing in UI text, logs, manifest description, and toolbar labels. Changes apply to AirGap.manifest, AirGap.py, commands/*, lib/*, and ui_components.py.