### PR TITLE
Resolve #13 - Reveal log file in Explorer/Finder

### DIFF
--- a/AirGap/commands/view_log.py
+++ b/AirGap/commands/view_log.py
@@ -51,9 +51,15 @@ class ViewLogExecuteHandler(adsk.core.CommandEventHandler):
             if sys.platform == "win32":
                 import os
 
-                os.startfile(path_str)
+                if log_path.is_file():
+                    subprocess.Popen(["explorer", "/select,", path_str])
+                else:
+                    os.startfile(path_str)
             else:
-                subprocess.Popen(["open", path_str])
+                if log_path.is_file():
+                    subprocess.Popen(["open", "-R", path_str])
+                else:
+                    subprocess.Popen(["open", path_str])
         except Exception:
             app = adsk.core.Application.get()
             app.userInterface.messageBox(f"Error opening log:\n{traceback.format_exc()}")


### PR DESCRIPTION
When executing the view-log command, check whether the target path is a file and, if so, reveal it in the system file browser (Windows: explorer /select, ; macOS: open -R). If the path is not a file, fall back to opening the path normally (os.startfile on Windows or open on macOS). This makes it easier to locate log files in their containing folder while preserving the previous fallback behavior and error handling.