### PR TITLE
Add auto-update system & release workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,71 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version (e.g., 1.1.0 or 1.1.0-beta.1)"
+        required: true
+      branch:
+        description: "Branch to bump version on"
+        required: true
+        default: "develop"
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate and update version
+        run: |
+          python3 << 'SCRIPT'
+          import json, re, sys
+
+          version = "${{ inputs.version }}"
+          pattern = r"^\d+\.\d+\.\d+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$"
+          if not re.match(pattern, version):
+              print(f"::error::Invalid version format: {version}")
+              sys.exit(1)
+
+          config_path = "AirGap/config.py"
+          with open(config_path) as f:
+              config_text = f.read()
+          old_match = re.search(r"VERSION\s*=\s*['\"]([^'\"]+)['\"]", config_text)
+          old_version = old_match.group(1) if old_match else "unknown"
+          new_config = re.sub(
+              r"(VERSION\s*=\s*['\"])[^'\"]+(['\"])",
+              rf"\g<1>{version}\g<2>",
+              config_text,
+          )
+          with open(config_path, "w") as f:
+              f.write(new_config)
+
+          manifest_path = "AirGap/AirGap.manifest"
+          with open(manifest_path) as f:
+              manifest = json.load(f)
+          manifest["version"] = version
+          with open(manifest_path, "w") as f:
+              json.dump(manifest, f, indent=4)
+              f.write("\n")
+
+          print(f"Version bumped: {old_version} -> {version}")
+          SCRIPT
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add AirGap/config.py AirGap/AirGap.manifest
+          git commit -m "Bump version to ${{ inputs.version }}"
+          git tag "v${{ inputs.version }}"
+          git push origin ${{ inputs.branch }} --tags

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   schedule:
     - cron: '0 6 * * 1'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   ruff:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: PR Checks
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   validate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: check
+
+      - name: Format check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check
+
+      - name: Syntax check
+        run: python -m compileall -q .
+
+      - name: Verify tag matches version files
+        run: |
+          python3 << 'SCRIPT'
+          import json, os, re, sys
+
+          tag = os.environ["GITHUB_REF_NAME"].lstrip("v")
+
+          with open("AirGap/AirGap.manifest") as f:
+              manifest_ver = json.load(f).get("version", "")
+
+          with open("AirGap/config.py") as f:
+              match = re.search(r"VERSION\s*=\s*['\"]([^'\"]+)['\"]", f.read())
+          config_ver = match.group(1) if match else ""
+
+          if tag != config_ver or tag != manifest_ver:
+              print(f"::error::Version mismatch: tag={tag}, config.py={config_ver}, manifest={manifest_ver}")
+              sys.exit(1)
+
+          print(f"Version verified: {tag}")
+          SCRIPT
+
+  release:
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version info
+        id: version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *"-beta"* ]] || [[ "$VERSION" == *"-rc"* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package release
+        run: |
+          zip -r "AirGap-v${{ steps.version.outputs.version }}.zip" AirGap/ \
+            -x "AirGap/__pycache__/*" "AirGap/**/__pycache__/*" "AirGap/**/*.pyc"
+
+      - name: Generate checksum
+        run: shasum -a 256 "AirGap-v${{ steps.version.outputs.version }}.zip" > SHA256SUMS
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [ "${{ steps.version.outputs.prerelease }}" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "${{ github.ref_name }}" \
+            "AirGap-v${{ steps.version.outputs.version }}.zip" \
+            SHA256SUMS \
+            --title "AirGap v${{ steps.version.outputs.version }}" \
+            --generate-notes \
+            $PRERELEASE_FLAG

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -2,9 +2,9 @@ name: Syntax Check
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   compile-check:

--- a/AirGap/AirGap.py
+++ b/AirGap/AirGap.py
@@ -11,6 +11,86 @@ _addin_path = os.path.dirname(os.path.abspath(__file__))
 if _addin_path not in sys.path:
     sys.path.insert(0, _addin_path)
 
+
+def _apply_pending_update():
+    import json
+    import shutil
+    from pathlib import Path
+
+    if sys.platform == "win32":
+        base_dir = Path(os.environ.get("APPDATA", Path.home())) / ".airgap"
+    else:
+        base_dir = Path.home() / ".airgap"
+
+    pending_file = base_dir / "update_pending.json"
+    if not pending_file.exists():
+        return False
+
+    try:
+        with open(pending_file, encoding="utf-8") as f:
+            pending = json.load(f)
+
+        staging_path = Path(pending["staging_path"])
+        if not staging_path.exists():
+            pending_file.unlink(missing_ok=True)
+            return False
+
+        addin_dir = Path(_addin_path)
+        backup_dir = base_dir / "update_backup"
+
+        if backup_dir.exists():
+            shutil.rmtree(backup_dir)
+        backup_dir.mkdir(parents=True, exist_ok=True)
+
+        for item in addin_dir.iterdir():
+            if item.name.startswith("."):
+                continue
+            dest = backup_dir / item.name
+            if item.is_dir():
+                shutil.copytree(item, dest)
+            else:
+                shutil.copy2(item, dest)
+
+        try:
+            for item in staging_path.iterdir():
+                dest = addin_dir / item.name
+                if item.is_dir():
+                    if dest.exists():
+                        shutil.rmtree(dest)
+                    shutil.copytree(item, dest)
+                else:
+                    shutil.copy2(item, dest)
+        except Exception:
+            for item in backup_dir.iterdir():
+                dest = addin_dir / item.name
+                if item.is_dir():
+                    if dest.exists():
+                        shutil.rmtree(dest)
+                    shutil.copytree(item, dest)
+                else:
+                    shutil.copy2(item, dest)
+            pending_file.unlink(missing_ok=True)
+            return False
+
+        shutil.rmtree(backup_dir, ignore_errors=True)
+        staging_parent = staging_path.parent
+        if staging_parent.name == "extracted":
+            shutil.rmtree(staging_parent.parent, ignore_errors=True)
+        else:
+            shutil.rmtree(staging_parent, ignore_errors=True)
+        pending_file.unlink(missing_ok=True)
+        return True
+
+    except Exception:
+        try:
+            pending_file.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return False
+
+
+_update_applied = _apply_pending_update()
+
 from commands.start_session import get_enforcer, get_interceptor
 from lib import ui_components
 from lib.audit_logger import AuditLogger
@@ -24,9 +104,12 @@ _auto_start_event = None
 _auto_start_handlers = []
 _crash_recovery_event = None
 _crash_recovery_handlers = []
+_update_check_event = None
+_update_check_handlers = []
 
 CUSTOM_EVENT_AUTO_START = "AirGap_AutoStart"
 CUSTOM_EVENT_CRASH_RECOVERY = "AirGap_CrashRecoveryComplete"
+CUSTOM_EVENT_UPDATE_CHECK = "AirGap_UpdateCheck"
 
 
 def run(context):
@@ -34,6 +117,17 @@ def run(context):
     try:
         _app = adsk.core.Application.get()
         _ui = _app.userInterface
+
+        if _update_applied:
+            import config as cfg
+
+            _ui.messageBox(
+                f"AirGap has been updated to version {cfg.VERSION}.\n\n"
+                "See the release notes on GitHub for details.",
+                "AirGap - Updated",
+                adsk.core.MessageBoxButtonTypes.OKButtonType,
+                adsk.core.MessageBoxIconTypes.InformationIconType,
+            )
 
         restored = _handle_crash_recovery(_app, _ui)
 
@@ -44,6 +138,7 @@ def run(context):
             _schedule_crash_recovery_completion(_app)
         else:
             _schedule_auto_start(_app)
+            _schedule_update_check(_app)
 
     except Exception:
         if _ui:
@@ -51,7 +146,7 @@ def run(context):
 
 
 def stop(context):
-    global _auto_start_event, _crash_recovery_event
+    global _auto_start_event, _crash_recovery_event, _update_check_event
     try:
         session = SessionManager.instance()
         if session.is_protected:
@@ -77,12 +172,18 @@ def stop(context):
                 _app.unregisterCustomEvent(CUSTOM_EVENT_CRASH_RECOVERY)
             except Exception:
                 pass
+            try:
+                _app.unregisterCustomEvent(CUSTOM_EVENT_UPDATE_CHECK)
+            except Exception:
+                pass
             ui_components.destroy_ui(_app)
 
         _auto_start_handlers.clear()
         _auto_start_event = None
         _crash_recovery_handlers.clear()
         _crash_recovery_event = None
+        _update_check_handlers.clear()
+        _update_check_event = None
 
     except Exception:
         if _ui:
@@ -367,3 +468,87 @@ class _AutoStartHandler(adsk.core.CustomEventHandler):
                 )
             except Exception:
                 pass
+
+
+def _schedule_update_check(app: adsk.core.Application):
+    global _update_check_event
+
+    if _update_applied:
+        return
+
+    settings = Settings.reload()
+    if not settings.auto_check_updates:
+        return
+
+    session = SessionManager.instance()
+    if session.is_protected:
+        return
+
+    _update_check_event = app.registerCustomEvent(CUSTOM_EVENT_UPDATE_CHECK)
+    handler = _UpdateCheckHandler()
+    _update_check_event.add(handler)
+    _update_check_handlers.append(handler)
+
+    thread = threading.Thread(target=_check_update_after_ready, args=(app, settings.update_channel))
+    thread.daemon = True
+    thread.start()
+
+
+def _check_update_after_ready(app: adsk.core.Application, channel: str):
+    import json
+    import time
+
+    import config as cfg
+
+    deadline = time.monotonic() + cfg.AUTO_START_READY_TIMEOUT
+    while time.monotonic() < deadline:
+        try:
+            if hasattr(app, "isStartupComplete") and app.isStartupComplete:
+                break
+            if app.activeViewport is not None:
+                break
+        except Exception:
+            pass
+        time.sleep(cfg.AUTO_START_READY_POLL)
+
+    time.sleep(cfg.AUTO_START_POST_READY_DELAY)
+
+    try:
+        from lib.updater import check_for_update
+
+        result = check_for_update(channel)
+        if result.update_available and not result.error:
+            payload = json.dumps(
+                {"version": result.latest_version, "prerelease": result.is_prerelease}
+            )
+            app.fireCustomEvent(CUSTOM_EVENT_UPDATE_CHECK, payload)
+    except Exception:
+        pass
+
+
+class _UpdateCheckHandler(adsk.core.CustomEventHandler):
+    def __init__(self):
+        super().__init__()
+
+    def notify(self, args):
+        try:
+            import json
+
+            app = adsk.core.Application.get()
+            ui = app.userInterface
+
+            payload = json.loads(args.additionalInfo) if args.additionalInfo else {}
+            version = payload.get("version", "")
+            prerelease = payload.get("prerelease", False)
+
+            label = f"{version} (beta)" if prerelease else version
+
+            ui.messageBox(
+                f"A new version of AirGap is available: {label}\n\n"
+                'Use "Check for Updates" in the AirGap toolbar to download it.',
+                "AirGap - Update Available",
+                adsk.core.MessageBoxButtonTypes.OKButtonType,
+                adsk.core.MessageBoxIconTypes.InformationIconType,
+            )
+        except Exception:
+            pass

--- a/AirGap/commands/__init__.py
+++ b/AirGap/commands/__init__.py
@@ -7,6 +7,7 @@ _handlers = []
 
 
 def register_commands(ui: adsk.core.UserInterface):
+    from commands.check_update import CheckUpdateCommand
     from commands.export_local import ExportLocalCommand
     from commands.settings import SettingsCommand
     from commands.start_session import StartSessionCommand
@@ -48,6 +49,13 @@ def register_commands(ui: adsk.core.UserInterface):
             "Configure AirGap auto-start and default settings.",
             "",
             SettingsCommand,
+        ),
+        (
+            config.CMD_CHECK_UPDATE,
+            "Check for Updates",
+            "Check for a newer version of AirGap.",
+            "",
+            CheckUpdateCommand,
         ),
     ]
 

--- a/AirGap/commands/check_update.py
+++ b/AirGap/commands/check_update.py
@@ -1,0 +1,127 @@
+import traceback
+
+import adsk.core
+
+from lib.session_manager import SessionManager
+from lib.settings import Settings
+from lib.updater import check_for_update, download_and_stage
+
+_handlers = []
+
+
+class CheckUpdateCommand(adsk.core.CommandCreatedEventHandler):
+    def __init__(self):
+        super().__init__()
+
+    def notify(self, args):
+        try:
+            cmd = args.command
+            cmd.isAutoExecute = True
+            handler = _CheckUpdateExecuteHandler()
+            cmd.execute.add(handler)
+            _handlers.append(handler)
+        except Exception:
+            app = adsk.core.Application.get()
+            app.userInterface.messageBox(f"Error creating update check:\n{traceback.format_exc()}")
+
+
+class _CheckUpdateExecuteHandler(adsk.core.CommandEventHandler):
+    def __init__(self):
+        super().__init__()
+
+    def notify(self, args):
+        try:
+            app = adsk.core.Application.get()
+            ui = app.userInterface
+
+            session = SessionManager.instance()
+            if session.is_protected:
+                ui.messageBox(
+                    "Cannot check for updates during an active AirGap session.\n\n"
+                    "End the session first, then check for updates.",
+                    "AirGap - Update Check",
+                    adsk.core.MessageBoxButtonTypes.OKButtonType,
+                    adsk.core.MessageBoxIconTypes.WarningIconType,
+                )
+                return
+
+            settings = Settings.instance()
+            channel = settings.update_channel
+
+            result = check_for_update(channel)
+
+            if result.error and not result.update_available:
+                ui.messageBox(
+                    f"Update check failed:\n\n{result.error}",
+                    "AirGap - Update Check",
+                    adsk.core.MessageBoxButtonTypes.OKButtonType,
+                    adsk.core.MessageBoxIconTypes.WarningIconType,
+                )
+                return
+
+            if not result.update_available:
+                ui.messageBox(
+                    f"You are running the latest version ({result.current_version}).",
+                    "AirGap - Update Check",
+                    adsk.core.MessageBoxButtonTypes.OKButtonType,
+                    adsk.core.MessageBoxIconTypes.InformationIconType,
+                )
+                return
+
+            if result.error:
+                ui.messageBox(
+                    f"A new version ({result.latest_version}) is available, "
+                    f"but it cannot be downloaded automatically:\n\n{result.error}\n\n"
+                    f"Please download it manually from GitHub.",
+                    "AirGap - Update Available",
+                    adsk.core.MessageBoxButtonTypes.OKButtonType,
+                    adsk.core.MessageBoxIconTypes.InformationIconType,
+                )
+                return
+
+            notes_preview = result.release_notes[:500] if result.release_notes else ""
+            notes_section = f"\n\nRelease Notes:\n{notes_preview}" if notes_preview else ""
+
+            answer = ui.messageBox(
+                f"A new version of AirGap is available!\n\n"
+                f"Current version: {result.current_version}\n"
+                f"Latest version: {result.latest_version}"
+                f"{'  (beta)' if result.is_prerelease else ''}"
+                f"{notes_section}\n\n"
+                f"Would you like to download and install?",
+                "AirGap - Update Available",
+                adsk.core.MessageBoxButtonTypes.YesNoButtonType,
+                adsk.core.MessageBoxIconTypes.InformationIconType,
+            )
+
+            if answer != adsk.core.DialogResults.DialogYes:
+                return
+
+            staging = download_and_stage(result)
+
+            if not staging.success:
+                ui.messageBox(
+                    f"Download failed:\n\n{staging.error}\n\n"
+                    f"You can download the update manually from GitHub.",
+                    "AirGap - Update Error",
+                    adsk.core.MessageBoxButtonTypes.OKButtonType,
+                    adsk.core.MessageBoxIconTypes.CriticalIconType,
+                )
+                return
+
+            ui.messageBox(
+                f"Update to version {result.latest_version} has been downloaded "
+                f"and verified.\n\n"
+                f"The update will be applied the next time Fusion 360 starts.\n\n"
+                f"Please restart Fusion 360 to complete the update.",
+                "AirGap - Update Staged",
+                adsk.core.MessageBoxButtonTypes.OKButtonType,
+                adsk.core.MessageBoxIconTypes.InformationIconType,
+            )
+
+        except Exception:
+            try:
+                app = adsk.core.Application.get()
+                app.userInterface.messageBox(f"Update check error:\n{traceback.format_exc()}")
+            except Exception:
+                pass

--- a/AirGap/commands/settings.py
+++ b/AirGap/commands/settings.py
@@ -41,6 +41,22 @@ class SettingsCommand(adsk.core.CommandCreatedEventHandler):
 
             inputs.addBoolValueInput("browseDir", "Browse...", False, "", False)
 
+            inputs.addBoolValueInput(
+                "autoCheckUpdates",
+                "Check for updates when Fusion starts",
+                True,
+                "",
+                settings.auto_check_updates,
+            )
+
+            channel_dropdown = inputs.addDropDownCommandInput(
+                "updateChannel",
+                "Update Channel",
+                adsk.core.DropDownStyles.TextListDropDownStyle,
+            )
+            channel_dropdown.listItems.add("Stable", settings.update_channel == "stable")
+            channel_dropdown.listItems.add("Beta", settings.update_channel == "beta")
+
             inputs.addTextBoxCommandInput(
                 "settingsInfo", "Settings File", str(config.SETTINGS_FILE), 1, True
             )
@@ -118,6 +134,12 @@ class SettingsExecuteHandler(adsk.core.CommandEventHandler):
             settings.auto_offline_on_startup = inputs.itemById("autoOffline").value
             settings.auto_start_session = inputs.itemById("autoSession").value
             settings.default_export_directory = inputs.itemById("defaultExportDir").value.strip()
+            settings.auto_check_updates = inputs.itemById("autoCheckUpdates").value
+
+            channel_input = inputs.itemById("updateChannel")
+            selected = channel_input.selectedItem
+            if selected:
+                settings.update_channel = selected.name.lower()
 
             settings.save()
 
@@ -125,7 +147,9 @@ class SettingsExecuteHandler(adsk.core.CommandEventHandler):
                 "SETTINGS_CHANGED",
                 f"Settings updated: auto_offline={settings.auto_offline_on_startup}, "
                 f"auto_session={settings.auto_start_session}, "
-                f"export_dir={settings.default_export_directory}",
+                f"export_dir={settings.default_export_directory}, "
+                f"auto_check_updates={settings.auto_check_updates}, "
+                f"update_channel={settings.update_channel}",
             )
 
             app = adsk.core.Application.get()

--- a/AirGap/config.py
+++ b/AirGap/config.py
@@ -14,6 +14,7 @@ CMD_STOP_SESSION = "airgap_stop_session"
 CMD_EXPORT_LOCAL = "airgap_export_local"
 CMD_VIEW_LOG = "airgap_view_log"
 CMD_SETTINGS = "airgap_settings"
+CMD_CHECK_UPDATE = "airgap_check_update"
 
 # Toolbar IDs
 TOOLBAR_TAB_ID = "AirGapTab"
@@ -43,6 +44,16 @@ DEFAULT_EXPORT_DIR = Path.home() / "AirGap_Exports"
 AUDIT_LOG_DIR = _BASE_DIR / "logs"
 SESSION_STATE_FILE = _BASE_DIR / "session_state.json"
 SETTINGS_FILE = _BASE_DIR / "settings.json"
+
+# Update system
+CUSTOM_EVENT_UPDATE_CHECK = "AirGap_UpdateCheck"
+GITHUB_OWNER = "infab-app"
+GITHUB_REPO = "airgap-fusion"
+GITHUB_API_BASE = "https://api.github.com"
+UPDATE_CHECK_TIMEOUT = 15
+UPDATE_STAGING_DIR = _BASE_DIR / "update_staging"
+UPDATE_PENDING_FILE = _BASE_DIR / "update_pending.json"
+UPDATE_BACKUP_DIR = _BASE_DIR / "update_backup"
 
 # Icon resource paths (relative to ADDIN_DIR)
 ICON_AIRGAP_ON = str(ADDIN_DIR / "resources" / "airgap_on")

--- a/AirGap/lib/github_client.py
+++ b/AirGap/lib/github_client.py
@@ -1,0 +1,80 @@
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import config
+
+
+def fetch_latest_release(channel: str) -> dict | None:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": f"AirGap/{config.VERSION}",
+    }
+    base = f"{config.GITHUB_API_BASE}/repos/{config.GITHUB_OWNER}/{config.GITHUB_REPO}"
+
+    try:
+        if channel == "stable":
+            url = f"{base}/releases/latest"
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=config.UPDATE_CHECK_TIMEOUT) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        else:
+            url = f"{base}/releases?per_page=20"
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=config.UPDATE_CHECK_TIMEOUT) as resp:
+                releases = json.loads(resp.read().decode("utf-8"))
+            if releases:
+                return releases[0]
+            return None
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError):
+        return None
+
+
+def download_asset(url: str, dest_path: Path) -> bool:
+    try:
+        headers = {"User-Agent": f"AirGap/{config.VERSION}"}
+        req = urllib.request.Request(url, headers=headers)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        with (
+            urllib.request.urlopen(req, timeout=config.UPDATE_CHECK_TIMEOUT) as resp,
+            open(dest_path, "wb") as f,
+        ):
+            while True:
+                chunk = resp.read(8192)
+                if not chunk:
+                    break
+                f.write(chunk)
+        return True
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError):
+        return False
+
+
+def download_checksums(tag_name: str) -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": f"AirGap/{config.VERSION}",
+    }
+    base = f"{config.GITHUB_API_BASE}/repos/{config.GITHUB_OWNER}/{config.GITHUB_REPO}"
+    url = f"{base}/releases/tags/{tag_name}"
+
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=config.UPDATE_CHECK_TIMEOUT) as resp:
+            release = json.loads(resp.read().decode("utf-8"))
+
+        for asset in release.get("assets", []):
+            if asset["name"] == "SHA256SUMS":
+                checksum_url = asset["browser_download_url"]
+                req = urllib.request.Request(checksum_url, headers=headers)
+                with urllib.request.urlopen(req, timeout=config.UPDATE_CHECK_TIMEOUT) as resp:
+                    text = resp.read().decode("utf-8")
+                checksums = {}
+                for line in text.strip().splitlines():
+                    parts = line.split(None, 1)
+                    if len(parts) == 2:
+                        checksums[parts[1].strip()] = parts[0].strip()
+                return checksums
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError):
+        pass
+    return {}

--- a/AirGap/lib/settings.py
+++ b/AirGap/lib/settings.py
@@ -8,6 +8,8 @@ _DEFAULTS = {
     "auto_offline_on_startup": False,
     "auto_start_session": False,
     "default_export_directory": str(config.DEFAULT_EXPORT_DIR),
+    "update_channel": "stable",
+    "auto_check_updates": False,
     "version": 1,
 }
 
@@ -74,3 +76,20 @@ class Settings:
     @default_export_directory.setter
     def default_export_directory(self, value: str):
         self._data["default_export_directory"] = value
+
+    @property
+    def update_channel(self) -> str:
+        return self._data.get("update_channel", "stable")
+
+    @update_channel.setter
+    def update_channel(self, value: str):
+        if value in ("stable", "beta"):
+            self._data["update_channel"] = value
+
+    @property
+    def auto_check_updates(self) -> bool:
+        return bool(self._data.get("auto_check_updates", False))
+
+    @auto_check_updates.setter
+    def auto_check_updates(self, value: bool):
+        self._data["auto_check_updates"] = value

--- a/AirGap/lib/ui_components.py
+++ b/AirGap/lib/ui_components.py
@@ -44,6 +44,7 @@ def create_ui(app: adsk.core.Application):
             config.CMD_EXPORT_LOCAL,
             config.CMD_VIEW_LOG,
             config.CMD_SETTINGS,
+            config.CMD_CHECK_UPDATE,
         ]
         for cmd_id in cmd_ids:
             ctrl = panel.controls.itemById(cmd_id)

--- a/AirGap/lib/updater.py
+++ b/AirGap/lib/updater.py
@@ -1,0 +1,295 @@
+import hashlib
+import json
+import re
+import shutil
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import config
+from lib import github_client
+
+
+@dataclass
+class UpdateCheckResult:
+    update_available: bool
+    current_version: str
+    latest_version: str
+    release_notes: str
+    download_url: str
+    asset_name: str
+    is_prerelease: bool
+    error: str | None
+
+
+@dataclass
+class StagingResult:
+    success: bool
+    staging_path: Path | None
+    error: str | None
+
+
+def parse_version(version_str: str) -> tuple[tuple[int, ...], str]:
+    v = version_str.lstrip("v")
+    pre = ""
+    if "-" in v:
+        v, pre = v.split("-", 1)
+    parts = tuple(int(p) for p in v.split("."))
+    return parts, pre
+
+
+def is_newer(latest: str, current: str) -> bool:
+    lat_parts, lat_pre = parse_version(latest)
+    cur_parts, cur_pre = parse_version(current)
+
+    if lat_parts > cur_parts:
+        return True
+    if lat_parts < cur_parts:
+        return False
+    if lat_pre == "" and cur_pre != "":
+        return True
+    if lat_pre != "" and cur_pre == "":
+        return False
+    return lat_pre > cur_pre
+
+
+def check_for_update(channel: str = "stable") -> UpdateCheckResult:
+    current = config.VERSION
+    release = github_client.fetch_latest_release(channel)
+
+    if release is None:
+        return UpdateCheckResult(
+            update_available=False,
+            current_version=current,
+            latest_version="",
+            release_notes="",
+            download_url="",
+            asset_name="",
+            is_prerelease=False,
+            error="Could not reach GitHub. Check your internet connection.",
+        )
+
+    tag = release.get("tag_name", "")
+    latest = tag.lstrip("v")
+
+    if not latest or not is_newer(latest, current):
+        return UpdateCheckResult(
+            update_available=False,
+            current_version=current,
+            latest_version=latest,
+            release_notes="",
+            download_url="",
+            asset_name="",
+            is_prerelease=release.get("prerelease", False),
+            error=None,
+        )
+
+    download_url = ""
+    asset_name = ""
+    for asset in release.get("assets", []):
+        name = asset.get("name", "")
+        if name.startswith("AirGap") and name.endswith(".zip"):
+            download_url = asset["browser_download_url"]
+            asset_name = name
+            break
+
+    if not download_url:
+        return UpdateCheckResult(
+            update_available=True,
+            current_version=current,
+            latest_version=latest,
+            release_notes=release.get("body", ""),
+            download_url="",
+            asset_name="",
+            is_prerelease=release.get("prerelease", False),
+            error="Release found but no downloadable zip asset attached.",
+        )
+
+    return UpdateCheckResult(
+        update_available=True,
+        current_version=current,
+        latest_version=latest,
+        release_notes=release.get("body", ""),
+        download_url=download_url,
+        asset_name=asset_name,
+        is_prerelease=release.get("prerelease", False),
+        error=None,
+    )
+
+
+def download_and_stage(result: UpdateCheckResult) -> StagingResult:
+    staging_dir = config.UPDATE_STAGING_DIR
+
+    try:
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir)
+        staging_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        return StagingResult(False, None, f"Could not create staging directory: {e}")
+
+    zip_path = staging_dir / result.asset_name
+    if not github_client.download_asset(result.download_url, zip_path):
+        return StagingResult(False, None, "Download failed. Please try again later.")
+
+    checksums = github_client.download_checksums(f"v{result.latest_version}")
+    if checksums:
+        expected = checksums.get(result.asset_name)
+        if expected:
+            actual = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+            if actual != expected:
+                shutil.rmtree(staging_dir, ignore_errors=True)
+                return StagingResult(
+                    False, None, "Checksum verification failed. Download may be corrupted."
+                )
+
+    if not zipfile.is_zipfile(zip_path):
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        return StagingResult(False, None, "Downloaded file is not a valid zip archive.")
+
+    extract_dir = staging_dir / "extracted"
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(extract_dir)
+    except zipfile.BadZipFile:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        return StagingResult(False, None, "Zip extraction failed.")
+
+    addin_dir = _find_addin_root(extract_dir)
+    if addin_dir is None:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        return StagingResult(
+            False, None, "Invalid archive structure: missing AirGap.py or AirGap.manifest."
+        )
+
+    extracted_config = addin_dir / "config.py"
+    if extracted_config.exists():
+        text = extracted_config.read_text(encoding="utf-8")
+        match = re.search(r"VERSION\s*=\s*['\"]([^'\"]+)['\"]", text)
+        if match:
+            extracted_ver = match.group(1)
+            if extracted_ver != result.latest_version:
+                shutil.rmtree(staging_dir, ignore_errors=True)
+                return StagingResult(
+                    False,
+                    None,
+                    f"Version mismatch: expected {result.latest_version}, got {extracted_ver}.",
+                )
+
+    pending = {
+        "version": result.latest_version,
+        "staging_path": str(addin_dir),
+        "timestamp": __import__("datetime").datetime.now().isoformat(),
+    }
+    config.UPDATE_PENDING_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = config.UPDATE_PENDING_FILE.with_suffix(".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(pending, f, indent=2)
+    tmp.replace(config.UPDATE_PENDING_FILE)
+
+    return StagingResult(True, addin_dir, None)
+
+
+def _find_addin_root(extract_dir: Path) -> Path | None:
+    if (extract_dir / "AirGap.py").exists() and (extract_dir / "AirGap.manifest").exists():
+        return extract_dir
+
+    for child in extract_dir.iterdir():
+        if (
+            child.is_dir()
+            and (child / "AirGap.py").exists()
+            and (child / "AirGap.manifest").exists()
+        ):
+            return child
+    return None
+
+
+def apply_pending_update(addin_path: str) -> bool:
+    """Replace add-in files from staged update. Must be called before lib imports."""
+    pending_file = _get_pending_file()
+    if pending_file is None or not pending_file.exists():
+        return False
+
+    try:
+        with open(pending_file, encoding="utf-8") as f:
+            pending = json.load(f)
+
+        staging_path = Path(pending["staging_path"])
+        if not staging_path.exists():
+            pending_file.unlink(missing_ok=True)
+            return False
+
+        addin_dir = Path(addin_path)
+        backup_dir = _get_backup_dir()
+
+        if backup_dir.exists():
+            shutil.rmtree(backup_dir)
+        backup_dir.mkdir(parents=True, exist_ok=True)
+
+        for item in addin_dir.iterdir():
+            if item.name.startswith("."):
+                continue
+            dest = backup_dir / item.name
+            if item.is_dir():
+                shutil.copytree(item, dest)
+            else:
+                shutil.copy2(item, dest)
+
+        try:
+            for item in staging_path.iterdir():
+                dest = addin_dir / item.name
+                if item.is_dir():
+                    if dest.exists():
+                        shutil.rmtree(dest)
+                    shutil.copytree(item, dest)
+                else:
+                    shutil.copy2(item, dest)
+        except Exception:
+            for item in backup_dir.iterdir():
+                dest = addin_dir / item.name
+                if item.is_dir():
+                    if dest.exists():
+                        shutil.rmtree(dest)
+                    shutil.copytree(item, dest)
+                else:
+                    shutil.copy2(item, dest)
+            pending_file.unlink(missing_ok=True)
+            return False
+
+        shutil.rmtree(backup_dir, ignore_errors=True)
+        staging_parent = staging_path.parent
+        if staging_parent.name == "extracted":
+            shutil.rmtree(staging_parent.parent, ignore_errors=True)
+        else:
+            shutil.rmtree(staging_parent, ignore_errors=True)
+        pending_file.unlink(missing_ok=True)
+
+        return True
+
+    except Exception:
+        try:
+            pending_file.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return False
+
+
+def _get_pending_file() -> Path | None:
+    import os
+    import sys
+
+    if sys.platform == "win32":
+        base = Path(os.environ.get("APPDATA", Path.home())) / ".airgap"
+    else:
+        base = Path.home() / ".airgap"
+    return base / "update_pending.json"
+
+
+def _get_backup_dir() -> Path:
+    import os
+    import sys
+
+    if sys.platform == "win32":
+        base = Path(os.environ.get("APPDATA", Path.home())) / ".airgap"
+    else:
+        base = Path.home() / ".airgap"
+    return base / "update_backup"


### PR DESCRIPTION
Introduce a full update system and related CI workflows. Adds lib/updater.py and lib/github_client.py to check GitHub releases, download/verify zip assets, stage updates and apply them on next start; implements CheckUpdateCommand and UI integration (menu item, settings to control auto-check and channel). AirGap.py now applies staged updates at startup and schedules background update checks, with user notifications. Adds release and bump-version GitHub Actions (release packaging, tag/version verification, checksum generation, and manual bump dispatch) and expands existing workflows to also run on develop. Misc: settings persistence for update options and minor config constants for update paths and GitHub repo info.