### PR TITLE
Add explanatory text and shorten checkbox labels

### DIFF
--- a/AirGap/commands/start_session.py
+++ b/AirGap/commands/start_session.py
@@ -40,10 +40,17 @@ class StartSessionCommand(adsk.core.CommandCreatedEventHandler):
 
             inputs.addBoolValueInput("browseDir", "Browse...", False, "", False)
 
+            inputs.addTextBoxCommandInput(
+                "confirmItarText",
+                "",
+                "All documents opened during this session will be treated "
+                "as export-controlled.",
+                2,
+                True,
+            )
             inputs.addBoolValueInput(
                 "confirmItar",
-                "I understand all documents opened during "
-                "this session will be treated as export-controlled",
+                "I understand",
                 True,
                 "",
                 False,

--- a/AirGap/commands/start_session.py
+++ b/AirGap/commands/start_session.py
@@ -43,8 +43,7 @@ class StartSessionCommand(adsk.core.CommandCreatedEventHandler):
             inputs.addTextBoxCommandInput(
                 "confirmItarText",
                 "",
-                "All documents opened during this session will be treated "
-                "as export-controlled.",
+                "All documents opened during this session will be treated as export-controlled.",
                 2,
                 True,
             )

--- a/AirGap/commands/stop_session.py
+++ b/AirGap/commands/stop_session.py
@@ -50,17 +50,32 @@ class StopSessionCommand(adsk.core.CommandCreatedEventHandler):
                     True,
                 )
 
+            inputs.addTextBoxCommandInput(
+                "confirmExportText",
+                "",
+                "All export-controlled data has been exported and no "
+                "protected documents remain open.",
+                2,
+                True,
+            )
             inputs.addBoolValueInput(
                 "confirmExport",
-                "I confirm all export-controlled data has been exported and no protected documents remain open",
+                "I confirm",
                 True,
                 "",
                 False,
             )
 
+            inputs.addTextBoxCommandInput(
+                "confirmCacheText",
+                "",
+                "I should clear Fusion\u2019s local cache per organizational policy.",
+                2,
+                True,
+            )
             inputs.addBoolValueInput(
                 "confirmCache",
-                "I understand I should clear Fusion's local cache per organizational policy",
+                "I acknowledge",
                 True,
                 "",
                 False,


### PR DESCRIPTION
Add TextBoxCommandInput explanatory text above confirmation checkboxes and simplify the checkbox labels for clarity. start_session.py gains a confirmItarText box explaining that opened documents are export-controlled and the checkbox label is shortened to "I understand". stop_session.py gains confirmExportText and confirmCacheText boxes and shortens the corresponding checkbox labels to "I confirm" and "I acknowledge". These UI tweaks improve readability and make the intent of each confirmation clearer.