### PR TITLE
Remove broken CAM support and add post-processing guidance

### DIFF
--- a/AirGap/commands/export_local.py
+++ b/AirGap/commands/export_local.py
@@ -1,7 +1,6 @@
 import traceback
 from pathlib import Path
 
-import adsk.cam
 import adsk.core
 import adsk.fusion
 
@@ -44,16 +43,18 @@ class ExportLocalCommand(adsk.core.CommandCreatedEventHandler):
             inputs.addBoolValueInput("exportSTL", "STL (.stl)", True, "", False)
             inputs.addBoolValueInput("exportIGES", "IGES (.iges)", True, "", False)
 
-            has_cam = LocalExportManager.has_cam_product()
-            cam_group = inputs.addGroupCommandInput("camGroup", "CAM Export")
-            cam_group.isExpanded = has_cam
-            cam_group.isVisible = has_cam
-
-            cam_children = cam_group.children
-            cam_children.addBoolValueInput("exportNC", "Post-Process NC Code", True, "", False)
-            cam_children.addBoolValueInput(
-                "exportSetupSheet", "Generate Setup Sheet", True, "", False
-            )
+            if LocalExportManager.has_cam_product():
+                cam_info = inputs.addTextBoxCommandInput(
+                    "camInfo",
+                    "CAM / Post Processing",
+                    "Post processing is safe while AirGap is active. Use Fusion's "
+                    "NC Program dialog to generate G-code. Post processing runs "
+                    "entirely on your local machine \u2014 your NC output is saved to "
+                    "your chosen folder, not to Autodesk servers.",
+                    4,
+                    True,
+                )
+                cam_info.isFullWidth = True
 
             execute_handler = ExportExecuteHandler()
             cmd.execute.add(execute_handler)
@@ -110,13 +111,6 @@ class ExportValidateHandler(adsk.core.ValidateInputsEventHandler):
                     has_format = True
                     break
 
-            cam_group = inputs.itemById("camGroup")
-            if cam_group and cam_group.isVisible:
-                nc_input = cam_group.children.itemById("exportNC")
-                sheet_input = cam_group.children.itemById("exportSetupSheet")
-                if (nc_input and nc_input.value) or (sheet_input and sheet_input.value):
-                    has_format = True
-
             args.areInputsValid = bool(dir_input.value.strip()) and has_format
         except Exception:
             args.areInputsValid = False
@@ -169,20 +163,6 @@ class ExportExecuteHandler(adsk.core.CommandEventHandler):
                 filepath = str(export_dir / f"{safe_name}.iges")
                 ok = LocalExportManager.export_iges(filepath, target_component)
                 results.append(("IGES", filepath, ok))
-
-            cam_group = inputs.itemById("camGroup")
-            if cam_group and cam_group.isVisible:
-                nc_input = cam_group.children.itemById("exportNC")
-                if nc_input and nc_input.value:
-                    cam_dir = str(export_dir / "cam_output")
-                    ok = LocalExportManager.post_process_cam(cam_dir, safe_name)
-                    results.append(("NC Code", cam_dir, ok))
-
-                sheet_input = cam_group.children.itemById("exportSetupSheet")
-                if sheet_input and sheet_input.value:
-                    sheet_dir = str(export_dir / "setup_sheets")
-                    ok = LocalExportManager.generate_setup_sheet(sheet_dir)
-                    results.append(("Setup Sheet", sheet_dir, ok))
 
             all_ok = all(r[2] for r in results)
             if all_ok and doc_name != "export":

--- a/AirGap/lib/export_manager.py
+++ b/AirGap/lib/export_manager.py
@@ -1,5 +1,4 @@
 import traceback
-from pathlib import Path
 
 import adsk.cam
 import adsk.core
@@ -107,69 +106,6 @@ class LocalExportManager:
         except Exception:
             AuditLogger.instance().log(
                 "EXPORT_ERROR", f"SAT export failed: {traceback.format_exc()}", "ERROR"
-            )
-            return False
-
-    @staticmethod
-    def post_process_cam(output_folder: str, program_name: str = "program", setup=None) -> bool:
-        try:
-            app = adsk.core.Application.get()
-            doc = app.activeDocument
-            cam_product = adsk.cam.CAM.cast(doc.products.itemByProductType("CAMProductType"))
-            if not cam_product:
-                return False
-
-            target_setup = setup or cam_product.setups.item(0)
-            if not target_setup:
-                return False
-
-            output_path = Path(output_folder)
-            output_path.mkdir(parents=True, exist_ok=True)
-
-            post_config = cam_product.genericPostFolder
-            post_input = adsk.cam.PostProcessInput.create(
-                str(program_name),
-                str(post_config),
-                str(output_path),
-                adsk.cam.PostOutputUnitOptions.DocumentUnitsOutput,
-            )
-            cam_product.postProcess(target_setup, post_input)
-
-            AuditLogger.instance().log("EXPORT_NC", f"NC code posted to: {output_folder}")
-            return True
-        except Exception:
-            AuditLogger.instance().log(
-                "EXPORT_ERROR", f"CAM post-process failed: {traceback.format_exc()}", "ERROR"
-            )
-            return False
-
-    @staticmethod
-    def generate_setup_sheet(output_folder: str, setup=None) -> bool:
-        try:
-            app = adsk.core.Application.get()
-            doc = app.activeDocument
-            cam_product = adsk.cam.CAM.cast(doc.products.itemByProductType("CAMProductType"))
-            if not cam_product:
-                return False
-
-            target_setup = setup or cam_product.setups.item(0)
-            if not target_setup:
-                return False
-
-            output_path = Path(output_folder)
-            output_path.mkdir(parents=True, exist_ok=True)
-
-            cam_product.generateSetupSheet(
-                adsk.cam.SetupSheetFormats.HTMLSetupSheetFormat, str(output_path), target_setup
-            )
-
-            AuditLogger.instance().log(
-                "EXPORT_SETUP_SHEET", f"Setup sheet generated at: {output_folder}"
-            )
-            return True
-        except Exception:
-            AuditLogger.instance().log(
-                "EXPORT_ERROR", f"Setup sheet generation failed: {traceback.format_exc()}", "ERROR"
             )
             return False
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ UNPROTECTED → ACTIVATING → PROTECTED → DEACTIVATING → UNPROTECTED
 
 1. **Start Session** — Forces Fusion into offline mode, begins monitoring
 2. **Work in Protected Mode** — Cloud saves are blocked, all opened documents are tracked
-3. **Export Locally** — Save .f3d, STEP, STL, IGES files and CAM output to local or network-attached storage
+3. **Export Locally** — Save .f3d, STEP, STL, IGES files to local or network-attached storage
 4. **End Session** — Verifies all documents were exported and closed before allowing deactivation
 
 ### Key Features
 
 - **Offline Enforcement** — Programmatically sets `app.isOffLine = True` and monitors via event handlers and a polling thread. If someone toggles Fusion back online, AirGap immediately re-enforces offline mode.
 - **Cloud Save Blocking** — Intercepts save operations via the `documentSaving` event and cancels them with a warning directing the user to export locally.
-- **Local Export** — Supports F3D (Fusion Archive), STEP, STL, IGES, SAT, CAM NC code post-processing, and setup sheet generation.
+- **Local Export** — Supports F3D (Fusion Archive), STEP, STL, IGES, and SAT.
 - **Audit Logging** — Append-only JSONL logs record every session event (start, stop, exports, blocked saves, violations) for compliance auditing.
 - **Crash Recovery** — Session state is persisted to disk. If Fusion crashes during a session, AirGap forces offline mode on restart and offers to restore the session.
 - **Cross-Platform** — Single Python codebase for Windows and macOS.
@@ -100,7 +100,7 @@ Once running, AirGap adds an **AirGap** tab to the toolbar in both the Design an
 ### Exporting Files
 
 1. Click **Export Locally**
-2. Select formats: F3D, STEP, STL, IGES (and CAM options if applicable)
+2. Select formats: F3D, STEP, STL, IGES
 3. Choose the target component
 4. Click **OK** — Files are saved to your local export directory
 

--- a/docs/ITAR_COMPLIANCE_GUIDE.md
+++ b/docs/ITAR_COMPLIANCE_GUIDE.md
@@ -12,7 +12,7 @@ Organizations handling ITAR-controlled data should consult with their compliance
 
 1. **Forces Offline Mode** — Programmatically sets Fusion 360 to offline mode before any ITAR work begins. Monitors and re-enforces if toggled.
 2. **Blocks Cloud Saves** — Intercepts all save operations and cancels them. Users must use "Export Locally" instead.
-3. **Local-Only Export** — Provides export to .f3d, STEP, STL, IGES, and CAM formats directly to local or network-attached storage.
+3. **Local-Only Export** — Provides export to .f3d, STEP, STL, IGES, and SAT formats directly to local or network-attached storage.
 4. **Audit Logging** — Records all session events in append-only JSONL log files for compliance auditing.
 5. **Crash Recovery** — If Fusion crashes during an ITAR session, AirGap forces offline mode on restart and offers to restore the session.
 
@@ -162,8 +162,6 @@ Each entry contains:
 | EXPORT_STEP | INFO | STEP file exported |
 | EXPORT_STL | INFO | STL file exported |
 | EXPORT_IGES | INFO | IGES file exported |
-| EXPORT_NC | INFO | NC code post-processed |
-| EXPORT_SETUP_SHEET | INFO | Setup sheet generated |
 | EXPORT_ERROR | ERROR | Export operation failed |
 | DEACTIVATION_BLOCKED | WARNING | Session end blocked (unexported docs) |
 | CRASH_RECOVERY | WARNING | Session restored after crash |


### PR DESCRIPTION
  **Summary**

  - Removes the non-functional "Post-Process NC Code" and "Generate Setup Sheet" controls from the Export Locally dialog. These poorly replicated Fusion's native NC Program workflow (hardcoded to generic post folder, first setup only, no post processor selection)
  - Replaces the CAM export group with an informational message (shown when CAM setups are detected) explaining that Fusion's native post processing is safe to use while AirGap is active, since it runs entirely locally                                                                                                                          
  - Updates README and ITAR Compliance Guide to remove CAM export references
                                                                                                                                                                            
  **Why**                                                       

AirGap doesn't need to replicate Fusion's NC Program / Post Process functionality. Post processing is a local operation — the .cps post processor runs on the user's machine and outputs G-code to a local folder. Combined with AirGap's offline enforcement and save interception, there is no risk of toolpath or G-code data reaching Autodesk servers. Users should use Fusion's built-in NC Program dialog instead.