### PR TITLE
Support .f3z Fusion archives with xrefs

### DIFF
--- a/AirGap/commands/export_local.py
+++ b/AirGap/commands/export_local.py
@@ -38,7 +38,11 @@ class ExportLocalCommand(adsk.core.CommandCreatedEventHandler):
             for name, _ in components:
                 comp_dropdown.listItems.add(name, name == "Root Component")
 
-            inputs.addBoolValueInput("exportF3D", "Fusion Archive (.f3d)", True, "", True)
+            has_xrefs = LocalExportManager.has_external_references()
+            archive_ext = "f3z" if has_xrefs else "f3d"
+            inputs.addBoolValueInput(
+                "exportF3D", f"Fusion Archive (.{archive_ext})", True, "", True
+            )
             inputs.addBoolValueInput("exportSTEP", "STEP (.step)", True, "", False)
             inputs.addBoolValueInput("exportSTL", "STL (.stl)", True, "", False)
             inputs.addBoolValueInput("exportIGES", "IGES (.iges)", True, "", False)
@@ -145,9 +149,12 @@ class ExportExecuteHandler(adsk.core.CommandEventHandler):
             results = []
 
             if inputs.itemById("exportF3D").value:
-                filepath = str(export_dir / f"{safe_name}.f3d")
+                has_xrefs = LocalExportManager.has_external_references()
+                archive_ext = "f3z" if has_xrefs else "f3d"
+                filepath = str(export_dir / f"{safe_name}.{archive_ext}")
                 ok = LocalExportManager.export_fusion_archive(filepath, target_component)
-                results.append(("F3D", filepath, ok))
+                fmt_label = "F3Z" if has_xrefs else "F3D"
+                results.append((fmt_label, filepath, ok))
 
             if inputs.itemById("exportSTEP").value:
                 filepath = str(export_dir / f"{safe_name}.step")

--- a/AirGap/config.py
+++ b/AirGap/config.py
@@ -32,7 +32,7 @@ AUTO_START_READY_POLL = 2
 AUTO_START_POST_READY_DELAY = 3
 
 # Allowed export formats
-ALLOWED_EXPORT_FORMATS = ["f3d", "step", "stl", "iges", "sat"]
+ALLOWED_EXPORT_FORMATS = ["f3d", "f3z", "step", "stl", "iges", "sat"]
 
 # Platform-dependent paths
 if sys.platform == "win32":

--- a/AirGap/lib/export_manager.py
+++ b/AirGap/lib/export_manager.py
@@ -20,12 +20,26 @@ class LocalExportManager:
             options = export_mgr.createFusionArchiveExportOptions(filepath, target)
             result = export_mgr.execute(options)
             if result:
-                AuditLogger.instance().log("EXPORT_F3D", f"Exported: {filepath}")
+                event_type = "EXPORT_F3Z" if filepath.endswith(".f3z") else "EXPORT_F3D"
+                AuditLogger.instance().log(event_type, f"Exported: {filepath}")
             return result
         except Exception:
             AuditLogger.instance().log(
-                "EXPORT_ERROR", f"F3D export failed: {traceback.format_exc()}", "ERROR"
+                "EXPORT_ERROR",
+                f"Fusion Archive export failed: {traceback.format_exc()}",
+                "ERROR",
             )
+            return False
+
+    @staticmethod
+    def has_external_references() -> bool:
+        try:
+            app = adsk.core.Application.get()
+            design = adsk.fusion.Design.cast(app.activeProduct)
+            if not design:
+                return False
+            return any(occ.isReferencedComponent for occ in design.rootComponent.allOccurrences)
+        except Exception:
             return False
 
     @staticmethod

--- a/docs/ITAR_COMPLIANCE_GUIDE.md
+++ b/docs/ITAR_COMPLIANCE_GUIDE.md
@@ -158,7 +158,8 @@ Each entry contains:
 | DOC_OPENED | INFO | Document opened during session |
 | DOC_CREATED | INFO | New document created during session |
 | DOC_CLOSED | INFO | Document closed during session |
-| EXPORT_F3D | INFO | Fusion Archive exported |
+| EXPORT_F3D | INFO | Fusion Archive (.f3d) exported |
+| EXPORT_F3Z | INFO | Fusion Archive (.f3z) with external references exported |
 | EXPORT_STEP | INFO | STEP file exported |
 | EXPORT_STL | INFO | STL file exported |
 | EXPORT_IGES | INFO | IGES file exported |


### PR DESCRIPTION
Detect external references and export Fusion archives as .f3z when referenced. Updates include:
- ExportLocalCommand: dynamically set archive extension and UI label (.f3z vs .f3d) and record results with correct label.
- LocalExportManager: add has_external_references() helper; audit log uses EXPORT_F3Z for .f3z exports and preserves EXPORT_F3D for .f3d. Error message text clarified.
- config: allow "f3z" in ALLOWED_EXPORT_FORMATS.
- docs: document new EXPORT_F3Z event. This makes exports accurate when assemblies contain external referenced components while preserving previous behavior when no xrefs are present.