### PR TITLE
Export: add .igs, refactor manager and logging

### DIFF
--- a/AirGap/commands/export_local.py
+++ b/AirGap/commands/export_local.py
@@ -45,7 +45,7 @@ class ExportLocalCommand(adsk.core.CommandCreatedEventHandler):
             )
             inputs.addBoolValueInput("exportSTEP", "STEP (.step)", True, "", False)
             inputs.addBoolValueInput("exportSTL", "STL (.stl)", True, "", False)
-            inputs.addBoolValueInput("exportIGES", "IGES (.iges)", True, "", False)
+            inputs.addBoolValueInput("exportIGES", "IGES (.igs)", True, "", False)
 
             if LocalExportManager.has_cam_product():
                 cam_info = inputs.addTextBoxCommandInput(
@@ -167,7 +167,7 @@ class ExportExecuteHandler(adsk.core.CommandEventHandler):
                 results.append(("STL", filepath, ok))
 
             if inputs.itemById("exportIGES").value:
-                filepath = str(export_dir / f"{safe_name}.iges")
+                filepath = str(export_dir / f"{safe_name}.igs")
                 ok = LocalExportManager.export_iges(filepath, target_component)
                 results.append(("IGES", filepath, ok))
 
@@ -179,6 +179,10 @@ class ExportExecuteHandler(adsk.core.CommandEventHandler):
             for fmt, path, ok in results:
                 status = "OK" if ok else "FAILED"
                 summary_lines.append(f"  [{status}] {fmt}: {path}")
+                if not ok:
+                    AuditLogger.instance().log(
+                        "EXPORT_ERROR", f"Export failed for {fmt}: {path}", "ERROR"
+                    )
             summary = "\n".join(summary_lines)
 
             icon = (

--- a/AirGap/config.py
+++ b/AirGap/config.py
@@ -32,7 +32,7 @@ AUTO_START_READY_POLL = 2
 AUTO_START_POST_READY_DELAY = 3
 
 # Allowed export formats
-ALLOWED_EXPORT_FORMATS = ["f3d", "f3z", "step", "stl", "iges", "sat"]
+ALLOWED_EXPORT_FORMATS = ["f3d", "f3z", "step", "stl", "igs", "sat"]
 
 # Platform-dependent paths
 if sys.platform == "win32":

--- a/AirGap/lib/export_manager.py
+++ b/AirGap/lib/export_manager.py
@@ -9,11 +9,31 @@ from lib.audit_logger import AuditLogger
 
 class LocalExportManager:
     @staticmethod
-    def export_fusion_archive(filepath: str, component=None) -> bool:
+    def _get_design():
         try:
             app = adsk.core.Application.get()
             design = adsk.fusion.Design.cast(app.activeProduct)
+            if design:
+                return design
+            doc = app.activeDocument
+            if doc:
+                for i in range(doc.products.count):
+                    product = doc.products.item(i)
+                    design = adsk.fusion.Design.cast(product)
+                    if design:
+                        return design
+            return None
+        except Exception:
+            return None
+
+    @staticmethod
+    def export_fusion_archive(filepath: str, component=None) -> bool:
+        try:
+            design = LocalExportManager._get_design()
             if not design:
+                AuditLogger.instance().log(
+                    "EXPORT_ERROR", "Fusion Archive export failed: no Design product available", "ERROR"
+                )
                 return False
             export_mgr = design.exportManager
             target = component or design.rootComponent
@@ -22,6 +42,10 @@ class LocalExportManager:
             if result:
                 event_type = "EXPORT_F3Z" if filepath.endswith(".f3z") else "EXPORT_F3D"
                 AuditLogger.instance().log(event_type, f"Exported: {filepath}")
+            else:
+                AuditLogger.instance().log(
+                    "EXPORT_ERROR", f"Fusion Archive export returned failure: {filepath}", "ERROR"
+                )
             return result
         except Exception:
             AuditLogger.instance().log(
@@ -34,8 +58,7 @@ class LocalExportManager:
     @staticmethod
     def has_external_references() -> bool:
         try:
-            app = adsk.core.Application.get()
-            design = adsk.fusion.Design.cast(app.activeProduct)
+            design = LocalExportManager._get_design()
             if not design:
                 return False
             return any(occ.isReferencedComponent for occ in design.rootComponent.allOccurrences)
@@ -45,9 +68,11 @@ class LocalExportManager:
     @staticmethod
     def export_step(filepath: str, component=None) -> bool:
         try:
-            app = adsk.core.Application.get()
-            design = adsk.fusion.Design.cast(app.activeProduct)
+            design = LocalExportManager._get_design()
             if not design:
+                AuditLogger.instance().log(
+                    "EXPORT_ERROR", "STEP export failed: no Design product available", "ERROR"
+                )
                 return False
             export_mgr = design.exportManager
             options = export_mgr.createSTEPExportOptions(
@@ -56,6 +81,10 @@ class LocalExportManager:
             result = export_mgr.execute(options)
             if result:
                 AuditLogger.instance().log("EXPORT_STEP", f"Exported: {filepath}")
+            else:
+                AuditLogger.instance().log(
+                    "EXPORT_ERROR", f"STEP export returned failure: {filepath}", "ERROR"
+                )
             return result
         except Exception:
             AuditLogger.instance().log(
@@ -66,9 +95,11 @@ class LocalExportManager:
     @staticmethod
     def export_stl(filepath: str, component=None) -> bool:
         try:
-            app = adsk.core.Application.get()
-            design = adsk.fusion.Design.cast(app.activeProduct)
+            design = LocalExportManager._get_design()
             if not design:
+                AuditLogger.instance().log(
+                    "EXPORT_ERROR", "STL export failed: no Design product available", "ERROR"
+                )
                 return False
             export_mgr = design.exportManager
             target = component or design.rootComponent
@@ -76,6 +107,10 @@ class LocalExportManager:
             result = export_mgr.execute(options)
             if result:
                 AuditLogger.instance().log("EXPORT_STL", f"Exported: {filepath}")
+            else:
+                AuditLogger.instance().log(
+                    "EXPORT_ERROR", f"STL export returned failure: {filepath}", "ERROR"
+                )
             return result
         except Exception:
             AuditLogger.instance().log(
@@ -86,9 +121,11 @@ class LocalExportManager:
     @staticmethod
     def export_iges(filepath: str, component=None) -> bool:
         try:
-            app = adsk.core.Application.get()
-            design = adsk.fusion.Design.cast(app.activeProduct)
+            design = LocalExportManager._get_design()
             if not design:
+                AuditLogger.instance().log(
+                    "EXPORT_ERROR", "IGES export failed: no Design product available", "ERROR"
+                )
                 return False
             export_mgr = design.exportManager
             options = export_mgr.createIGESExportOptions(
@@ -97,6 +134,10 @@ class LocalExportManager:
             result = export_mgr.execute(options)
             if result:
                 AuditLogger.instance().log("EXPORT_IGES", f"Exported: {filepath}")
+            else:
+                AuditLogger.instance().log(
+                    "EXPORT_ERROR", f"IGES export returned failure: {filepath}", "ERROR"
+                )
             return result
         except Exception:
             AuditLogger.instance().log(
@@ -107,15 +148,21 @@ class LocalExportManager:
     @staticmethod
     def export_sat(filepath: str, component=None) -> bool:
         try:
-            app = adsk.core.Application.get()
-            design = adsk.fusion.Design.cast(app.activeProduct)
+            design = LocalExportManager._get_design()
             if not design:
+                AuditLogger.instance().log(
+                    "EXPORT_ERROR", "SAT export failed: no Design product available", "ERROR"
+                )
                 return False
             export_mgr = design.exportManager
             options = export_mgr.createSATExportOptions(filepath, component or design.rootComponent)
             result = export_mgr.execute(options)
             if result:
                 AuditLogger.instance().log("EXPORT_SAT", f"Exported: {filepath}")
+            else:
+                AuditLogger.instance().log(
+                    "EXPORT_ERROR", f"SAT export returned failure: {filepath}", "ERROR"
+                )
             return result
         except Exception:
             AuditLogger.instance().log(
@@ -126,8 +173,7 @@ class LocalExportManager:
     @staticmethod
     def get_components():
         try:
-            app = adsk.core.Application.get()
-            design = adsk.fusion.Design.cast(app.activeProduct)
+            design = LocalExportManager._get_design()
             if not design:
                 return []
             root = design.rootComponent

--- a/AirGap/lib/export_manager.py
+++ b/AirGap/lib/export_manager.py
@@ -32,7 +32,9 @@ class LocalExportManager:
             design = LocalExportManager._get_design()
             if not design:
                 AuditLogger.instance().log(
-                    "EXPORT_ERROR", "Fusion Archive export failed: no Design product available", "ERROR"
+                    "EXPORT_ERROR",
+                    "Fusion Archive export failed: no Design product available",
+                    "ERROR",
                 )
                 return False
             export_mgr = design.exportManager


### PR DESCRIPTION
Rename IGES extension to .igs in UI and file paths and update allowed formats. Introduce LocalExportManager._get_design to reliably find the active Design product (searching document products) and replace direct app/activeProduct usage. Add AuditLogger error logs when no Design is available or when export executions return failure, and log success events consistently. Small change in export_local also logs export failures to the audit log and aggregates results. These changes improve robustness and diagnostics for local exports.