### PR TITLE
Add configurable audit log directory

### DIFF
--- a/AirGap/AirGap.py
+++ b/AirGap/AirGap.py
@@ -123,6 +123,10 @@ def run(context):
                 adsk.core.MessageBoxIconTypes.InformationIconType,
             )
 
+        _settings = Settings.instance()
+        if _settings.log_directory:
+            AuditLogger.instance().set_log_dir(_settings.log_directory)
+
         restored = _handle_crash_recovery(_app, _ui)
 
         ui_components.create_ui(_app)

--- a/AirGap/commands/settings.py
+++ b/AirGap/commands/settings.py
@@ -41,6 +41,14 @@ class SettingsCommand(adsk.core.CommandCreatedEventHandler):
 
             inputs.addBoolValueInput("browseDir", "Browse...", False, "", False)
 
+            inputs.addStringValueInput(
+                "logDir",
+                "Log Directory",
+                settings.log_directory if settings.log_directory else str(config.AUDIT_LOG_DIR),
+            )
+
+            inputs.addBoolValueInput("browseLogDir", "Browse...", False, "", False)
+
             inputs.addBoolValueInput(
                 "autoCheckUpdates",
                 "Check for updates when Fusion starts",
@@ -99,6 +107,16 @@ class SettingsInputChangedHandler(adsk.core.InputChangedEventHandler):
                     dir_input = inputs.itemById("defaultExportDir")
                     dir_input.value = folder_dlg.folder
 
+            elif changed_input.id == "browseLogDir":
+                app = adsk.core.Application.get()
+                ui = app.userInterface
+                folder_dlg = ui.createFolderDialog()
+                folder_dlg.title = "Select Log Directory"
+                result = folder_dlg.showDialog()
+                if result == adsk.core.DialogResults.DialogOK:
+                    dir_input = inputs.itemById("logDir")
+                    dir_input.value = folder_dlg.folder
+
             elif changed_input.id == "autoOffline":
                 auto_offline = inputs.itemById("autoOffline")
                 auto_session = inputs.itemById("autoSession")
@@ -117,7 +135,14 @@ class SettingsValidateHandler(adsk.core.ValidateInputsEventHandler):
         try:
             inputs = args.inputs
             dir_input = inputs.itemById("defaultExportDir")
-            args.areInputsValid = bool(dir_input.value.strip())
+            if not dir_input.value.strip():
+                args.areInputsValid = False
+                return
+            log_dir_input = inputs.itemById("logDir")
+            if not log_dir_input.value.strip():
+                args.areInputsValid = False
+                return
+            args.areInputsValid = True
         except Exception:
             args.areInputsValid = False
 
@@ -134,6 +159,14 @@ class SettingsExecuteHandler(adsk.core.CommandEventHandler):
             settings.auto_offline_on_startup = inputs.itemById("autoOffline").value
             settings.auto_start_session = inputs.itemById("autoSession").value
             settings.default_export_directory = inputs.itemById("defaultExportDir").value.strip()
+
+            log_dir_value = inputs.itemById("logDir").value.strip()
+            if log_dir_value == str(config.AUDIT_LOG_DIR):
+                settings.log_directory = ""
+            else:
+                settings.log_directory = log_dir_value
+            AuditLogger.instance().set_log_dir(settings.log_directory)
+
             settings.auto_check_updates = inputs.itemById("autoCheckUpdates").value
 
             channel_input = inputs.itemById("updateChannel")
@@ -148,6 +181,7 @@ class SettingsExecuteHandler(adsk.core.CommandEventHandler):
                 f"Settings updated: auto_offline={settings.auto_offline_on_startup}, "
                 f"auto_session={settings.auto_start_session}, "
                 f"export_dir={settings.default_export_directory}, "
+                f"log_dir={settings.log_directory or 'default'}, "
                 f"auto_check_updates={settings.auto_check_updates}, "
                 f"update_channel={settings.update_channel}",
             )

--- a/AirGap/lib/audit_logger.py
+++ b/AirGap/lib/audit_logger.py
@@ -24,7 +24,11 @@ class AuditLogger:
 
     def start_session_log(self, session_id: str):
         self._session_id = session_id
-        self._log_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self._log_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            self._log_dir = Path(config.AUDIT_LOG_DIR)
+            self._log_dir.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         filename = f"airgap_{timestamp}_{session_id}.jsonl"
         self._current_log_file = self._log_dir / filename
@@ -46,7 +50,11 @@ class AuditLogger:
 
         log_file = self._current_log_file
         if log_file is None:
-            self._log_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                self._log_dir.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                self._log_dir = Path(config.AUDIT_LOG_DIR)
+                self._log_dir.mkdir(parents=True, exist_ok=True)
             log_file = self._log_dir / "airgap_unsessioned.jsonl"
 
         try:
@@ -60,6 +68,12 @@ class AuditLogger:
 
     def get_log_dir(self):
         return self._log_dir
+
+    def set_log_dir(self, path: str):
+        if path.strip():
+            self._log_dir = Path(path)
+        else:
+            self._log_dir = Path(config.AUDIT_LOG_DIR)
 
     @staticmethod
     def _get_user():

--- a/AirGap/lib/settings.py
+++ b/AirGap/lib/settings.py
@@ -10,6 +10,7 @@ _DEFAULTS = {
     "default_export_directory": str(config.DEFAULT_EXPORT_DIR),
     "update_channel": "stable",
     "auto_check_updates": False,
+    "log_directory": "",
     "version": 1,
 }
 
@@ -76,6 +77,14 @@ class Settings:
     @default_export_directory.setter
     def default_export_directory(self, value: str):
         self._data["default_export_directory"] = value
+
+    @property
+    def log_directory(self) -> str:
+        return self._data.get("log_directory", "")
+
+    @log_directory.setter
+    def log_directory(self, value: str):
+        self._data["log_directory"] = value
 
     @property
     def update_channel(self) -> str:


### PR DESCRIPTION
Add support for a configurable audit log directory across the app. Introduces a log_directory setting with getter/setter in Settings, adds a log directory string field and browse button to the Settings UI, and validates the input. AuditLogger gains set_log_dir/get_log_dir and hardens directory creation with an OSError fallback to the default AUDIT_LOG_DIR. The chosen log directory is applied at startup (if set) and when settings are saved; empty value falls back to the default path. Also improve logging of the saved settings to include the log dir.