### PR TITLE
Enhancement/cache clearing

### DIFF
--- a/AirGap/commands/settings.py
+++ b/AirGap/commands/settings.py
@@ -68,6 +68,14 @@ class SettingsCommand(adsk.core.CommandCreatedEventHandler):
 
             _add_autosave_inputs(inputs, settings)
 
+            inputs.addBoolValueInput(
+                "autoClearCache",
+                "Auto-clear Fusion cache when ending sessions",
+                True,
+                "",
+                settings.auto_clear_cache,
+            )
+
             inputs.addTextBoxCommandInput(
                 "settingsInfo", "Settings File", str(config.SETTINGS_FILE), 1, True
             )
@@ -259,6 +267,8 @@ class SettingsExecuteHandler(adsk.core.CommandEventHandler):
                     pass
                 settings.autosave_directory = inputs.itemById("autosaveDir").value.strip()
 
+            settings.auto_clear_cache = inputs.itemById("autoClearCache").value
+
             settings.save()
 
             AuditLogger.instance().log(
@@ -271,7 +281,8 @@ class SettingsExecuteHandler(adsk.core.CommandEventHandler):
                 f"update_channel={settings.update_channel}, "
                 f"autosave={settings.autosave_enabled}, "
                 f"autosave_interval={settings.autosave_interval_minutes}m, "
-                f"autosave_max={settings.autosave_max_versions}",
+                f"autosave_max={settings.autosave_max_versions}, "
+                f"auto_clear_cache={settings.auto_clear_cache}",
             )
 
             app = adsk.core.Application.get()

--- a/AirGap/commands/stop_session.py
+++ b/AirGap/commands/stop_session.py
@@ -6,7 +6,7 @@ import adsk.core
 from commands.start_session import get_enforcer, get_interceptor
 from lib.audit_logger import AuditLogger
 from lib.persistence import SessionPersistence
-from lib.session_manager import SessionManager, SessionState
+from lib.session_manager import SessionManager, SessionState, is_default_document
 from lib.ui_components import update_button_visibility
 
 _handlers = []
@@ -105,6 +105,19 @@ class StopSessionCommand(adsk.core.CommandCreatedEventHandler):
                 False,
             )
 
+            from lib.settings import Settings
+
+            if Settings.instance().auto_clear_cache:
+                inputs.addTextBoxCommandInput(
+                    "autoClearInfo",
+                    "",
+                    "AirGap will attempt to automatically clear Fusion's local cache "
+                    "after performing a final autosave. Some files may not be "
+                    "deletable while Fusion is running.",
+                    2,
+                    True,
+                )
+
             execute_handler = StopSessionExecuteHandler()
             cmd.execute.add(execute_handler)
             _handlers.append(execute_handler)
@@ -150,6 +163,65 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
             session = SessionManager.instance()
             logger = AuditLogger.instance()
 
+            from lib.settings import Settings
+
+            auto_clear = Settings.instance().auto_clear_cache
+            clear_result = None
+
+            if auto_clear:
+                try:
+                    from lib.autosave_manager import AutosaveManager
+
+                    autosave_mgr = AutosaveManager.instance()
+                    if autosave_mgr.is_active:
+                        logger.log(
+                            "CACHE_CLEAR_AUTOSAVE",
+                            "Performing final autosave before cache clear",
+                        )
+                        autosave_mgr.perform_autosave()
+                except Exception:
+                    logger.log(
+                        "CACHE_CLEAR_AUTOSAVE_FAILED",
+                        f"Final autosave before cache clear failed: {traceback.format_exc()}",
+                        "WARNING",
+                    )
+
+                try:
+                    from pathlib import Path
+
+                    from lib.export_manager import LocalExportManager
+
+                    doc = app.activeDocument
+                    if doc and not is_default_document(doc.name):
+                        doc_name = doc.name
+                        safe = "".join(
+                            c if c.isalnum() or c in "-_ " else "_" for c in doc_name
+                        )
+                        export_dir = Path(session.export_directory) / safe
+                        export_dir.mkdir(parents=True, exist_ok=True)
+                        has_xrefs = LocalExportManager.has_external_references()
+                        ext = ".f3z" if has_xrefs else ".f3d"
+                        filepath = str(export_dir / f"{safe}{ext}")
+                        ok = LocalExportManager.export_fusion_archive(filepath)
+                        if ok:
+                            session.mark_exported(doc_name)
+                            logger.log(
+                                "CACHE_CLEAR_EXPORT",
+                                f"Final export before cache clear: {filepath}",
+                            )
+                        else:
+                            logger.log(
+                                "CACHE_CLEAR_EXPORT_FAILED",
+                                f"Final export failed for {doc_name}",
+                                "WARNING",
+                            )
+                except Exception:
+                    logger.log(
+                        "CACHE_CLEAR_EXPORT_FAILED",
+                        f"Final export before cache clear failed: {traceback.format_exc()}",
+                        "WARNING",
+                    )
+
             if not session.transition_to(SessionState.DEACTIVATING):
                 ui.messageBox("Cannot stop session: invalid state transition.", "AirGap - Error")
                 return
@@ -180,6 +252,24 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
             else:
                 logger.log("SESSION_END", f"AirGap session ended cleanly.{duration_str}")
 
+            if auto_clear:
+                try:
+                    from lib.cache_clearer import clear_fusion_cache
+
+                    logger.log("CACHE_CLEAR_START", "Automatic cache clear initiated")
+                    clear_result = clear_fusion_cache()
+                    logger.log(
+                        "CACHE_CLEAR_COMPLETE",
+                        clear_result.summary(),
+                        "WARNING" if clear_result.files_failed > 0 else "INFO",
+                    )
+                except Exception:
+                    logger.log(
+                        "CACHE_CLEAR_ERROR",
+                        f"Cache clear failed: {traceback.format_exc()}",
+                        "ERROR",
+                    )
+
             try:
                 from lib.autosave_manager import AutosaveManager
 
@@ -197,6 +287,31 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
 
             update_button_visibility(SessionState.UNPROTECTED)
 
+            cache_msg = ""
+            if auto_clear and clear_result is not None:
+                if clear_result.success:
+                    cache_msg = (
+                        f"\n\nCache cleared successfully. "
+                        f"{clear_result.files_deleted} items removed."
+                    )
+                elif clear_result.partial:
+                    cache_msg = (
+                        f"\n\nCache partially cleared: {clear_result.files_deleted} items "
+                        f"removed, {clear_result.files_failed} items could not be deleted "
+                        f"(likely locked by Fusion). Consider clearing manually after "
+                        f"closing Fusion."
+                    )
+                else:
+                    cache_msg = (
+                        "\n\nCache clear failed. Please clear the cache manually "
+                        "before going online. Refer to the compliance guide."
+                    )
+            elif auto_clear:
+                cache_msg = (
+                    "\n\nCache clear encountered an error. Please clear the cache "
+                    "manually before going online. Refer to the compliance guide."
+                )
+
             ui.messageBox(
                 "AIRGAP SESSION ENDED\n\n"
                 "Offline enforcement and save blocking have been deactivated.\n\n"
@@ -204,7 +319,7 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
                 "manually go online when you are confident no export-controlled data "
                 "remains in Fusion's local cache.\n\n"
                 "Refer to the compliance guide for cache clearing "
-                "procedures.",
+                f"procedures.{cache_msg}",
                 "AirGap - Session Ended",
                 adsk.core.MessageBoxButtonTypes.OKButtonType,
                 adsk.core.MessageBoxIconTypes.InformationIconType,

--- a/AirGap/commands/stop_session.py
+++ b/AirGap/commands/stop_session.py
@@ -186,14 +186,21 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
                         "WARNING",
                     )
 
-                try:
-                    from pathlib import Path
+                from pathlib import Path
 
-                    from lib.export_manager import LocalExportManager
+                from lib.export_manager import LocalExportManager
 
-                    doc = app.activeDocument
-                    if doc and not is_default_document(doc.name):
+                for i in range(app.documents.count):
+                    try:
+                        doc = app.documents.item(i)
+                        if not doc or is_default_document(doc.name):
+                            continue
                         doc_name = doc.name
+                        if doc_name not in session.tracked_documents:
+                            continue
+                        if doc_name in session.exported_documents:
+                            continue
+                        doc.activate()
                         safe = "".join(
                             c if c.isalnum() or c in "-_ " else "_" for c in doc_name
                         )
@@ -215,12 +222,13 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
                                 f"Final export failed for {doc_name}",
                                 "WARNING",
                             )
-                except Exception:
-                    logger.log(
-                        "CACHE_CLEAR_EXPORT_FAILED",
-                        f"Final export before cache clear failed: {traceback.format_exc()}",
-                        "WARNING",
-                    )
+                    except Exception:
+                        logger.log(
+                            "CACHE_CLEAR_EXPORT_FAILED",
+                            f"Final export before cache clear failed for document: "
+                            f"{traceback.format_exc()}",
+                            "WARNING",
+                        )
 
             if not session.transition_to(SessionState.DEACTIVATING):
                 ui.messageBox("Cannot stop session: invalid state transition.", "AirGap - Error")
@@ -258,9 +266,12 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
 
                     logger.log("CACHE_CLEAR_START", "Automatic cache clear initiated")
                     clear_result = clear_fusion_cache()
+                    detail = clear_result.summary()
+                    if clear_result.errors:
+                        detail += f" | Errors: {clear_result.errors}"
                     logger.log(
                         "CACHE_CLEAR_COMPLETE",
-                        clear_result.summary(),
+                        detail,
                         "WARNING" if clear_result.files_failed > 0 else "INFO",
                     )
                 except Exception:
@@ -294,12 +305,27 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
                         f"\n\nCache cleared successfully. "
                         f"{clear_result.files_deleted} items removed."
                     )
-                elif clear_result.partial:
+                elif clear_result.partial or clear_result.files_failed > 0:
+                    failed_f3ds = []
+                    for err in clear_result.errors:
+                        path_part = err.split(":")[0].strip()
+                        if path_part.endswith(".f3d"):
+                            name = Path(path_part).name
+                            display = name.rsplit(".", 2)[0] if "." in name else name
+                            if display not in failed_f3ds:
+                                failed_f3ds.append(display)
                     cache_msg = (
                         f"\n\nCache partially cleared: {clear_result.files_deleted} items "
                         f"removed, {clear_result.files_failed} items could not be deleted "
-                        f"(likely locked by Fusion). Consider clearing manually after "
-                        f"closing Fusion."
+                        f"(likely locked by Fusion)."
+                    )
+                    if failed_f3ds:
+                        cache_msg += (
+                            f"\n\nCached designs that could not be removed:"
+                            f"\n- " + "\n- ".join(failed_f3ds)
+                        )
+                    cache_msg += (
+                        "\n\nConsider clearing manually after closing Fusion."
                     )
                 else:
                     cache_msg = (

--- a/AirGap/commands/stop_session.py
+++ b/AirGap/commands/stop_session.py
@@ -201,9 +201,7 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
                         if doc_name in session.exported_documents:
                             continue
                         doc.activate()
-                        safe = "".join(
-                            c if c.isalnum() or c in "-_ " else "_" for c in doc_name
-                        )
+                        safe = "".join(c if c.isalnum() or c in "-_ " else "_" for c in doc_name)
                         export_dir = Path(session.export_directory) / safe
                         export_dir.mkdir(parents=True, exist_ok=True)
                         has_xrefs = LocalExportManager.has_external_references()
@@ -321,12 +319,10 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
                     )
                     if failed_f3ds:
                         cache_msg += (
-                            f"\n\nCached designs that could not be removed:"
-                            f"\n- " + "\n- ".join(failed_f3ds)
+                            "\n\nCached designs that could not be removed:"
+                            "\n- " + "\n- ".join(failed_f3ds)
                         )
-                    cache_msg += (
-                        "\n\nConsider clearing manually after closing Fusion."
-                    )
+                    cache_msg += "\n\nConsider clearing manually after closing Fusion."
                 else:
                     cache_msg = (
                         "\n\nCache clear failed. Please clear the cache manually "

--- a/AirGap/config.py
+++ b/AirGap/config.py
@@ -57,6 +57,26 @@ AUDIT_LOG_DIR = _BASE_DIR / "logs"
 SESSION_STATE_FILE = _BASE_DIR / "session_state.json"
 SETTINGS_FILE = _BASE_DIR / "settings.json"
 
+# Fusion 360 cache base directories
+if sys.platform == "win32":
+    FUSION_CACHE_BASES = [
+        Path(os.environ.get("LOCALAPPDATA", "")) / "Autodesk" / "Autodesk Fusion 360",
+    ]
+else:
+    FUSION_CACHE_BASES = [
+        Path.home() / "Library" / "Application Support" / "Autodesk" / "Autodesk Fusion 360",
+        Path.home()
+        / "Library"
+        / "Containers"
+        / "com.autodesk.mas.fusion360"
+        / "Data"
+        / "Library"
+        / "Application Support"
+        / "Autodesk",
+    ]
+
+FUSION_CACHE_SUBDIRS = ["W.Login", "DataCache"]
+
 # Update system
 CUSTOM_EVENT_UPDATE_CHECK = "AirGap_UpdateCheck"
 GITHUB_OWNER = "infab-app"

--- a/AirGap/config.py
+++ b/AirGap/config.py
@@ -75,7 +75,8 @@ else:
         / "Autodesk",
     ]
 
-FUSION_CACHE_SUBDIRS = ["W.Login", "DataCache"]
+FUSION_CACHE_SUBDIRS = ["W.login"]
+FUSION_CACHE_SENSITIVE_PATTERNS = ["*.f3d", "*.f3z"]
 
 # Update system
 CUSTOM_EVENT_UPDATE_CHECK = "AirGap_UpdateCheck"

--- a/AirGap/lib/cache_clearer.py
+++ b/AirGap/lib/cache_clearer.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 from pathlib import Path
 
@@ -31,53 +32,102 @@ class CacheClearResult:
         )
 
 
-def _safe_rmtree(
-    root: Path, result: CacheClearResult, logger: "AuditLogger"
-) -> tuple[int, int]:
-    """Walk bottom-up and delete, checking every node for symlinks."""
-    deleted = 0
-    failed = 0
-    for dirpath, dirnames, filenames in os.walk(root, topdown=False, followlinks=False):
-        dp = Path(dirpath)
-        for name in filenames:
-            fp = dp / name
-            if fp.is_symlink():
-                result.errors.append(f"Skipped symlink: {fp}")
-                logger.log(
-                    "CACHE_CLEAR_SKIP",
-                    f"Skipped symlink during tree walk: {fp}",
-                    "WARNING",
-                )
-                continue
-            try:
-                fp.unlink()
-                deleted += 1
-            except OSError as e:
-                failed += 1
-                result.errors.append(f"{fp}: {e}")
-        for name in dirnames:
-            dp_child = dp / name
-            if dp_child.is_symlink():
-                result.errors.append(f"Skipped symlink: {dp_child}")
-                logger.log(
-                    "CACHE_CLEAR_SKIP",
-                    f"Skipped symlink during tree walk: {dp_child}",
-                    "WARNING",
-                )
-                continue
-            try:
-                dp_child.rmdir()
-                deleted += 1
-            except OSError as e:
-                failed += 1
-                result.errors.append(f"{dp_child}: {e}")
+def _discover_user_dirs(base: Path) -> list[Path]:
+    """Find user-hash directories inside a Fusion cache base."""
+    user_dirs = []
     try:
-        root.rmdir()
-        deleted += 1
+        for entry in os.scandir(base):
+            if not entry.is_dir(follow_symlinks=False):
+                continue
+            if entry.name.startswith("."):
+                continue
+            name = entry.name
+            if len(name) >= 8 and name.isalnum() and name.isupper():
+                user_dirs.append(Path(entry.path))
+    except OSError:
+        pass
+    return user_dirs
+
+
+def _delete_sensitive_files_recursive(
+    directory: Path, patterns: list[str], result: CacheClearResult, logger: "AuditLogger"
+):
+    """Recursively walk a directory and delete only files matching sensitive patterns."""
+    if not directory.exists():
+        return
+    if directory.is_symlink():
+        result.errors.append(f"Skipped symlink: {directory}")
+        logger.log(
+            "CACHE_CLEAR_SKIP",
+            f"Directory is a symlink, skipped: {directory}",
+            "WARNING",
+        )
+        return
+
+    result.dirs_attempted.append(str(directory))
+
+    try:
+        for dirpath, _dirnames, filenames in os.walk(
+            directory, topdown=True, followlinks=False
+        ):
+            dp = Path(dirpath)
+            for name in filenames:
+                if not any(fnmatch.fnmatch(name, pat) for pat in patterns):
+                    continue
+                fp = dp / name
+                if fp.is_symlink():
+                    result.errors.append(f"Skipped symlink: {fp}")
+                    continue
+                try:
+                    fp.unlink()
+                    result.files_deleted += 1
+                except OSError as e:
+                    result.files_failed += 1
+                    result.errors.append(f"{fp}: {e}")
     except OSError as e:
-        failed += 1
-        result.errors.append(f"{root}: {e}")
-    return deleted, failed
+        result.errors.append(f"Cannot walk {directory}: {e}")
+        logger.log(
+            "CACHE_CLEAR_ERROR",
+            f"Cannot walk directory {directory}: {e}",
+            "ERROR",
+        )
+
+
+_EMPTY_CACHE_QUEUE = (
+    '<?xml version="1.0" encoding="UTF-16" standalone="no" ?>\n'
+    "<CacheCommandUrns/>\n"
+).encode("utf-16")
+
+
+def _reset_upload_queue(
+    wlogin_dir: Path, result: CacheClearResult, logger: "AuditLogger"
+):
+    """Reset CacheCommandQueue XML files to empty, preventing queued uploads."""
+    if not wlogin_dir.exists():
+        return
+    try:
+        for entry in os.scandir(wlogin_dir):
+            if not entry.is_file(follow_symlinks=False):
+                continue
+            if not fnmatch.fnmatch(entry.name, "CacheCommandQueue*.xml"):
+                continue
+            entry_path = Path(entry.path)
+            if entry_path.is_symlink():
+                result.errors.append(f"Skipped symlink: {entry_path}")
+                continue
+            try:
+                entry_path.write_bytes(_EMPTY_CACHE_QUEUE)
+                result.files_deleted += 1
+            except OSError as e:
+                result.files_failed += 1
+                result.errors.append(f"{entry_path}: {e}")
+    except OSError as e:
+        result.errors.append(f"Cannot scan {wlogin_dir}: {e}")
+        logger.log(
+            "CACHE_CLEAR_ERROR",
+            f"Cannot scan for upload queues in {wlogin_dir}: {e}",
+            "ERROR",
+        )
 
 
 def clear_fusion_cache() -> CacheClearResult:
@@ -87,62 +137,20 @@ def clear_fusion_cache() -> CacheClearResult:
     for base in config.FUSION_CACHE_BASES:
         if not base.exists():
             continue
-        for subdir_name in config.FUSION_CACHE_SUBDIRS:
-            cache_dir = base / subdir_name
-            if not cache_dir.exists():
-                continue
-            if cache_dir.is_symlink():
-                result.errors.append(f"Skipped symlink: {cache_dir}")
-                logger.log(
-                    "CACHE_CLEAR_SKIP",
-                    f"Cache directory is a symlink, skipped: {cache_dir}",
-                    "WARNING",
+
+        user_dirs = _discover_user_dirs(base)
+        if not user_dirs:
+            continue
+
+        for user_dir in user_dirs:
+            for subdir_name in config.FUSION_CACHE_SUBDIRS:
+                subdir = user_dir / subdir_name
+                _delete_sensitive_files_recursive(
+                    subdir,
+                    config.FUSION_CACHE_SENSITIVE_PATTERNS,
+                    result,
+                    logger,
                 )
-                continue
-
-            result.dirs_attempted.append(str(cache_dir))
-            dir_deleted = 0
-            dir_failed = 0
-
-            try:
-                entries = list(os.scandir(cache_dir))
-            except OSError as e:
-                result.errors.append(f"Cannot scan {cache_dir}: {e}")
-                logger.log(
-                    "CACHE_CLEAR_ERROR",
-                    f"Cannot scan cache directory {cache_dir}: {e}",
-                    "ERROR",
-                )
-                continue
-
-            if len(entries) > 10000:
-                logger.log(
-                    "CACHE_CLEAR_LARGE_DIR",
-                    f"Large cache directory ({len(entries)} top-level entries): {cache_dir}",
-                    "WARNING",
-                )
-
-            for entry in entries:
-                try:
-                    entry_path = Path(entry.path)
-                    if entry_path.is_symlink():
-                        result.errors.append(f"Skipped symlink: {entry_path}")
-                        continue
-                    if entry.is_dir(follow_symlinks=False):
-                        deleted, failed = _safe_rmtree(entry_path, result, logger)
-                        dir_deleted += deleted
-                        dir_failed += failed
-                    else:
-                        entry_path.unlink()
-                        dir_deleted += 1
-                except OSError as e:
-                    dir_failed += 1
-                    result.errors.append(f"{entry.path}: {e}")
-
-            result.files_deleted += dir_deleted
-            result.files_failed += dir_failed
-
-            if dir_failed == 0:
-                result.dirs_cleared.append(str(cache_dir))
+                _reset_upload_queue(subdir, result, logger)
 
     return result

--- a/AirGap/lib/cache_clearer.py
+++ b/AirGap/lib/cache_clearer.py
@@ -1,0 +1,89 @@
+import os
+import shutil
+from pathlib import Path
+
+import config
+from lib.audit_logger import AuditLogger
+
+
+class CacheClearResult:
+    def __init__(self):
+        self.dirs_attempted: list[str] = []
+        self.dirs_cleared: list[str] = []
+        self.files_deleted: int = 0
+        self.files_failed: int = 0
+        self.errors: list[str] = []
+
+    @property
+    def success(self) -> bool:
+        return self.files_failed == 0 and len(self.errors) == 0
+
+    @property
+    def partial(self) -> bool:
+        return self.files_deleted > 0 and self.files_failed > 0
+
+    def summary(self) -> str:
+        status = "success" if self.success else ("partial" if self.partial else "failed")
+        return (
+            f"Cache clear {status}: "
+            f"{self.files_deleted} items deleted, "
+            f"{self.files_failed} items failed, "
+            f"{len(self.dirs_attempted)} dirs attempted"
+        )
+
+
+def clear_fusion_cache() -> CacheClearResult:
+    result = CacheClearResult()
+    logger = AuditLogger.instance()
+
+    for base in config.FUSION_CACHE_BASES:
+        if not base.exists():
+            continue
+        for subdir_name in config.FUSION_CACHE_SUBDIRS:
+            cache_dir = base / subdir_name
+            if not cache_dir.exists():
+                continue
+            if cache_dir.is_symlink():
+                result.errors.append(f"Skipped symlink: {cache_dir}")
+                logger.log(
+                    "CACHE_CLEAR_SKIP",
+                    f"Cache directory is a symlink, skipped: {cache_dir}",
+                    "WARNING",
+                )
+                continue
+
+            result.dirs_attempted.append(str(cache_dir))
+            dir_deleted = 0
+            dir_failed = 0
+
+            try:
+                for entry in os.scandir(cache_dir):
+                    try:
+                        entry_path = Path(entry.path)
+                        if entry_path.is_symlink():
+                            result.errors.append(f"Skipped symlink: {entry_path}")
+                            continue
+                        if entry.is_dir(follow_symlinks=False):
+                            shutil.rmtree(entry_path)
+                        else:
+                            entry_path.unlink()
+                        dir_deleted += 1
+                    except OSError as e:
+                        dir_failed += 1
+                        result.errors.append(f"{entry.path}: {e}")
+            except OSError as e:
+                result.errors.append(f"Cannot scan {cache_dir}: {e}")
+                logger.log(
+                    "CACHE_CLEAR_ERROR",
+                    f"Cannot scan cache directory {cache_dir}: {e}",
+                    "ERROR",
+                )
+                continue
+
+            result.files_deleted += dir_deleted
+            result.files_failed += dir_failed
+
+            if dir_failed == 0:
+                result.dirs_cleared.append(str(cache_dir))
+
+    return result

--- a/AirGap/lib/cache_clearer.py
+++ b/AirGap/lib/cache_clearer.py
@@ -67,9 +67,7 @@ def _delete_sensitive_files_recursive(
     result.dirs_attempted.append(str(directory))
 
     try:
-        for dirpath, _dirnames, filenames in os.walk(
-            directory, topdown=True, followlinks=False
-        ):
+        for dirpath, _dirnames, filenames in os.walk(directory, topdown=True, followlinks=False):
             dp = Path(dirpath)
             for name in filenames:
                 if not any(fnmatch.fnmatch(name, pat) for pat in patterns):
@@ -94,14 +92,11 @@ def _delete_sensitive_files_recursive(
 
 
 _EMPTY_CACHE_QUEUE = (
-    '<?xml version="1.0" encoding="UTF-16" standalone="no" ?>\n'
-    "<CacheCommandUrns/>\n"
+    '<?xml version="1.0" encoding="UTF-16" standalone="no" ?>\n<CacheCommandUrns/>\n'
 ).encode("utf-16")
 
 
-def _reset_upload_queue(
-    wlogin_dir: Path, result: CacheClearResult, logger: "AuditLogger"
-):
+def _reset_upload_queue(wlogin_dir: Path, result: CacheClearResult, logger: "AuditLogger"):
     """Reset CacheCommandQueue XML files to empty, preventing queued uploads."""
     if not wlogin_dir.exists():
         return

--- a/AirGap/lib/cache_clearer.py
+++ b/AirGap/lib/cache_clearer.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from pathlib import Path
 
 import config
@@ -32,6 +31,55 @@ class CacheClearResult:
         )
 
 
+def _safe_rmtree(
+    root: Path, result: CacheClearResult, logger: "AuditLogger"
+) -> tuple[int, int]:
+    """Walk bottom-up and delete, checking every node for symlinks."""
+    deleted = 0
+    failed = 0
+    for dirpath, dirnames, filenames in os.walk(root, topdown=False, followlinks=False):
+        dp = Path(dirpath)
+        for name in filenames:
+            fp = dp / name
+            if fp.is_symlink():
+                result.errors.append(f"Skipped symlink: {fp}")
+                logger.log(
+                    "CACHE_CLEAR_SKIP",
+                    f"Skipped symlink during tree walk: {fp}",
+                    "WARNING",
+                )
+                continue
+            try:
+                fp.unlink()
+                deleted += 1
+            except OSError as e:
+                failed += 1
+                result.errors.append(f"{fp}: {e}")
+        for name in dirnames:
+            dp_child = dp / name
+            if dp_child.is_symlink():
+                result.errors.append(f"Skipped symlink: {dp_child}")
+                logger.log(
+                    "CACHE_CLEAR_SKIP",
+                    f"Skipped symlink during tree walk: {dp_child}",
+                    "WARNING",
+                )
+                continue
+            try:
+                dp_child.rmdir()
+                deleted += 1
+            except OSError as e:
+                failed += 1
+                result.errors.append(f"{dp_child}: {e}")
+    try:
+        root.rmdir()
+        deleted += 1
+    except OSError as e:
+        failed += 1
+        result.errors.append(f"{root}: {e}")
+    return deleted, failed
+
+
 def clear_fusion_cache() -> CacheClearResult:
     result = CacheClearResult()
     logger = AuditLogger.instance()
@@ -57,20 +105,7 @@ def clear_fusion_cache() -> CacheClearResult:
             dir_failed = 0
 
             try:
-                for entry in os.scandir(cache_dir):
-                    try:
-                        entry_path = Path(entry.path)
-                        if entry_path.is_symlink():
-                            result.errors.append(f"Skipped symlink: {entry_path}")
-                            continue
-                        if entry.is_dir(follow_symlinks=False):
-                            shutil.rmtree(entry_path)
-                        else:
-                            entry_path.unlink()
-                        dir_deleted += 1
-                    except OSError as e:
-                        dir_failed += 1
-                        result.errors.append(f"{entry.path}: {e}")
+                entries = list(os.scandir(cache_dir))
             except OSError as e:
                 result.errors.append(f"Cannot scan {cache_dir}: {e}")
                 logger.log(
@@ -79,6 +114,30 @@ def clear_fusion_cache() -> CacheClearResult:
                     "ERROR",
                 )
                 continue
+
+            if len(entries) > 10000:
+                logger.log(
+                    "CACHE_CLEAR_LARGE_DIR",
+                    f"Large cache directory ({len(entries)} top-level entries): {cache_dir}",
+                    "WARNING",
+                )
+
+            for entry in entries:
+                try:
+                    entry_path = Path(entry.path)
+                    if entry_path.is_symlink():
+                        result.errors.append(f"Skipped symlink: {entry_path}")
+                        continue
+                    if entry.is_dir(follow_symlinks=False):
+                        deleted, failed = _safe_rmtree(entry_path, result, logger)
+                        dir_deleted += deleted
+                        dir_failed += failed
+                    else:
+                        entry_path.unlink()
+                        dir_deleted += 1
+                except OSError as e:
+                    dir_failed += 1
+                    result.errors.append(f"{entry.path}: {e}")
 
             result.files_deleted += dir_deleted
             result.files_failed += dir_failed

--- a/AirGap/lib/settings.py
+++ b/AirGap/lib/settings.py
@@ -17,6 +17,7 @@ _DEFAULTS = {
     "autosave_interval_minutes": 10,
     "autosave_max_versions": 3,
     "autosave_directory": "",
+    "auto_clear_cache": False,
     "version": 1,
 }
 
@@ -154,3 +155,11 @@ class Settings:
         if value and validate_safe_path(value) is None:
             return
         self._data["autosave_directory"] = value
+
+    @property
+    def auto_clear_cache(self) -> bool:
+        return bool(self._data.get("auto_clear_cache", False))
+
+    @auto_clear_cache.setter
+    def auto_clear_cache(self, value: bool):
+        self._data["auto_clear_cache"] = value

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ UNPROTECTED → ACTIVATING → PROTECTED → DEACTIVATING → UNPROTECTED
 - **Local Export** — Supports F3D (Fusion Archive), STEP, STL, IGES, and SAT.
 - **Audit Logging** — Append-only JSONL logs record every session event (start, stop, exports, blocked saves, violations) for compliance auditing.
 - **Crash Recovery** — Session state is persisted to disk. If Fusion crashes during a session, AirGap forces offline mode on restart and offers to restore the session.
+- **Cache Clearing** — Optionally clears Fusion's local data cache (`W.Login`, `DataCache`) when ending a session to reduce the risk of cached design data syncing to Autodesk servers when going back online.
 - **Cross-Platform** — Single Python codebase for Windows and macOS.
 - **Auto-Update** - Optionally check for updates automatically on Fusion startup, notifying you of any new updates and can update itself after user confirmation
 
@@ -112,6 +113,8 @@ Once running, AirGap adds an **AirGap** tab to the toolbar in both the Design an
 4. Confirm both acknowledgment checkboxes
 5. Click **OK** — Enforcement is deactivated
 
+If **Auto-clear Fusion cache** is enabled in Settings, AirGap will perform a final autosave and export, then attempt to delete the contents of Fusion's local cache directories. Some files may remain locked while Fusion is running — AirGap will report what succeeded and what needs manual cleanup. See the [ITAR Compliance Guide](docs/ITAR_COMPLIANCE_GUIDE.md) for details on cache clearing scope and manual procedures.
+
 ### Enabling Auto-updates
 
 1. Click **AirGap Settings**
@@ -138,6 +141,7 @@ airgap-fusion/
 │   │   ├── ui_components.py   # Toolbar and button setup
 │   │   ├── persistence.py     # Crash recovery state
 │   │   ├── settings.py        # User settings management
+│   │   ├── cache_clearer.py   # Fusion cache clearing
 │   │   ├── github_client.py   # GitHub Releases API client
 │   │   └── updater.py         # Self-update orchestration
 │   ├── commands/
@@ -166,7 +170,7 @@ Each line is a JSON object with timestamp, session ID, event type, detail, sever
 
 ## Important Limitations
 
-- **Not a standalone ITAR solution.** AirGap adds application-level safeguards but is not a substitute for compliant network architecture, access controls, or organizational policies. Autodesk Fusion's local cache may retain design data that syncs when going back online. See the [ITAR Compliance Guide](docs/ITAR_COMPLIANCE_GUIDE.md) for cache clearing procedures.
+- **Not a standalone ITAR solution.** AirGap adds application-level safeguards but is not a substitute for compliant network architecture, access controls, or organizational policies. Autodesk Fusion's local cache may retain design data that syncs when going back online. AirGap can automatically clear the primary cache directories, but some files may remain locked while Fusion is running and other locations (temp files, OS caches) are not covered. See the [ITAR Compliance Guide](docs/ITAR_COMPLIANCE_GUIDE.md) for full details.
 - **14-day license window.** Fusion requires internet access for license validation every 14 days. Plan ITAR work within this window, then clear the cache before reconnecting.
 - **Session-level tracking.** All documents opened during a session are treated as ITAR-controlled. There is no per-file classification.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ UNPROTECTED → ACTIVATING → PROTECTED → DEACTIVATING → UNPROTECTED
 - **Local Export** — Supports F3D (Fusion Archive), STEP, STL, IGES, and SAT.
 - **Audit Logging** — Append-only JSONL logs record every session event (start, stop, exports, blocked saves, violations) for compliance auditing.
 - **Crash Recovery** — Session state is persisted to disk. If Fusion crashes during a session, AirGap forces offline mode on restart and offers to restore the session.
-- **Cache Clearing** — Optionally clears Fusion's local data cache (`W.Login`, `DataCache`) when ending a session to reduce the risk of cached design data syncing to Autodesk servers when going back online.
+- **Cache Clearing** — Optionally clears cached design files (`.f3d`, `.f3z`) and resets pending upload queues when ending a session to reduce the risk of cached design data syncing to Autodesk servers when going back online. Offline mode metadata is preserved so Fusion can remain offline after clearing.
 - **Cross-Platform** — Single Python codebase for Windows and macOS.
 - **Auto-Update** - Optionally check for updates automatically on Fusion startup, notifying you of any new updates and can update itself after user confirmation
 
@@ -113,7 +113,7 @@ Once running, AirGap adds an **AirGap** tab to the toolbar in both the Design an
 4. Confirm both acknowledgment checkboxes
 5. Click **OK** — Enforcement is deactivated
 
-If **Auto-clear Fusion cache** is enabled in Settings, AirGap will perform a final autosave and export, then attempt to delete the contents of Fusion's local cache directories. Some files may remain locked while Fusion is running — AirGap will report what succeeded and what needs manual cleanup. See the [ITAR Compliance Guide](docs/ITAR_COMPLIANCE_GUIDE.md) for details on cache clearing scope and manual procedures.
+If **Auto-clear Fusion cache** is enabled in Settings, AirGap will perform a final autosave, export all tracked unexported documents as `.f3d`/`.f3z` files to the session export directory, and then attempt to delete the contents of Fusion's local cache directories. Some cache files may remain locked while Fusion is running — AirGap will report what succeeded and what needs manual cleanup. See the [ITAR Compliance Guide](docs/ITAR_COMPLIANCE_GUIDE.md) for details on cache clearing scope and manual procedures.
 
 ### Enabling Auto-updates
 

--- a/docs/ITAR_COMPLIANCE_GUIDE.md
+++ b/docs/ITAR_COMPLIANCE_GUIDE.md
@@ -41,7 +41,17 @@ For Mac App Store installations:
 ~/Library/Containers/com.autodesk.mas.fusion360/Data/Library/Application Support/Autodesk/
 ```
 
-### Cache Clearing Procedure
+### Automatic Cache Clearing
+
+AirGap can automatically clear Fusion's local cache when ending an ITAR session. Enable this via **Settings > Auto-clear Fusion cache when ending sessions**. When enabled, AirGap will:
+
+1. Perform a final autosave of any active work
+2. Export the active document to the session export directory
+3. Delete the contents of `W.Login` and `DataCache` directories
+
+Some files may not be deletable while Fusion is still running. AirGap will report which items succeeded and which failed. For any items that could not be deleted, follow the manual procedure below.
+
+### Manual Cache Clearing Procedure
 
 After ending an ITAR session and before allowing Fusion to go online:
 
@@ -52,6 +62,17 @@ After ending an ITAR session and before allowing Fusion to go online:
 5. Only then should you allow Fusion to go online
 
 **WARNING:** Clearing the cache will remove ALL locally cached designs, not just ITAR-controlled ones. Ensure all work is exported before clearing.
+
+### Cache Clearing Scope and Limitations
+
+AirGap's cache clearing targets the `W.Login` and `DataCache` directories, which contain the primary design data cache. The following locations are **not** covered by AirGap's automatic clearing and may retain residual data:
+
+- **OS temp directories** (`%TEMP%` on Windows, `/tmp` on macOS) — may contain Fusion working files
+- **Fusion thumbnail caches** — preview images of designs
+- **OS-level caches** — filesystem caches, virtual memory swap files, and hibernation files
+- **Fusion telemetry queue** — usage analytics data that may be queued for transmission (see Limitations below)
+
+For maximum data residue reduction, organizations should consider full-disk encryption on ITAR workstations and OS-level secure deletion tools as complementary measures.
 
 ---
 
@@ -165,6 +186,11 @@ Each entry contains:
 | EXPORT_IGES | INFO | IGES file exported |
 | EXPORT_ERROR | ERROR | Export operation failed |
 | DEACTIVATION_BLOCKED | WARNING | Session end blocked (unexported docs) |
+| CACHE_CLEAR_START | INFO | Automatic cache clear initiated |
+| CACHE_CLEAR_COMPLETE | INFO/WARNING | Cache clear finished (WARNING if partial) |
+| CACHE_CLEAR_SKIP | WARNING | Symlink encountered and skipped during cache clear |
+| CACHE_CLEAR_ERROR | ERROR | Cache clear operation failed |
+| CACHE_CLEAR_LARGE_DIR | WARNING | Cache directory contains >10,000 entries |
 | CRASH_RECOVERY | WARNING | Session restored after crash |
 | ADDIN_STOPPING | WARNING | Add-in stopping with active session |
 
@@ -176,4 +202,4 @@ Each entry contains:
 2. **Local cache persistence** — Fusion's cache may retain design data even after documents are closed. Manual cache clearing is required.
 3. **14-day license limit** — Fusion requires periodic internet access for licensing. This creates a window where data could sync if cache is not cleared.
 4. **No file-level ITAR tagging** — AirGap treats ALL documents during a session as ITAR-controlled. There is no per-file classification.
-5. **Application telemetry** — Fusion may send usage telemetry even in offline mode (though design data is not included).
+5. **Application telemetry** — Fusion may send usage telemetry even in offline mode (though design data is not included). Telemetry data may also be queued for transmission while offline and sent when the machine next goes online, regardless of whether the cache has been cleared. Cache clearing does not affect queued telemetry.

--- a/docs/ITAR_COMPLIANCE_GUIDE.md
+++ b/docs/ITAR_COMPLIANCE_GUIDE.md
@@ -24,32 +24,48 @@ Even with AirGap active, Fusion 360 maintains a local cache of design data. When
 
 ### Cache Locations
 
+Fusion 360 stores cached data under user-specific directories (alphanumeric hashes) within its application support folder:
+
 **Windows:**
 ```
-%LocalAppData%\Autodesk\Autodesk Fusion 360\
+%LocalAppData%\Autodesk\Autodesk Fusion 360\<user_hash>\
 ```
-Specifically:
-- `W.Login\` — Contains cached design files
-- `DataCache\` — General data cache
 
 **macOS:**
 ```
-~/Library/Application Support/Autodesk/Autodesk Fusion 360/
+~/Library/Application Support/Autodesk/Autodesk Fusion 360/<user_hash>/
 ```
 For Mac App Store installations:
 ```
-~/Library/Containers/com.autodesk.mas.fusion360/Data/Library/Application Support/Autodesk/
+~/Library/Containers/com.autodesk.mas.fusion360/Data/Library/Application Support/Autodesk/<user_hash>/
 ```
+
+Within each user directory, the cache contains:
+- `W.login/` — Contains cached design files (`.f3d`, `.f3z`), structural metadata, and upload queues
+- `NsCloudBrowserCache*.dat` — Cloud browser cache (Data Panel file/project listings)
+- `OfflineCache.xml` — Offline mode state metadata (licensing, entitlements, timebomb)
+
+### What AirGap Clears vs. Preserves
+
+AirGap performs **targeted** cache clearing — only removing data that contains actual design content while preserving the metadata Fusion requires to remain in offline mode:
+
+| Item | Action | Reason |
+|------|--------|--------|
+| `.f3d` / `.f3z` files in `W.login` | **Deleted** | Contain actual 3D geometry, dimensions, and manufacturing data |
+| `CacheCommandQueue*.xml` in `W.login` | **Reset to empty** | Prevents queued design uploads from syncing when going online |
+| `NsCloudBrowserCache*.dat` | **Preserved** | Contains only Data Panel directory listings (project names, folder structure) — no design geometry. Fusion cannot enter offline mode without this file |
+| `OfflineCache.xml` | **Preserved** | Contains licensing/entitlement state and offline timebomb. Fusion cannot remain offline without this file |
+| `W.login` structural files (`M2/index.xml`, directory structure) | **Preserved** | Cache infrastructure Fusion needs to function offline |
 
 ### Automatic Cache Clearing
 
 AirGap can automatically clear Fusion's local cache when ending an ITAR session. Enable this via **Settings > Auto-clear Fusion cache when ending sessions**. When enabled, AirGap will:
 
 1. Perform a final autosave of any active work
-2. Export the active document to the session export directory
-3. Delete the contents of `W.Login` and `DataCache` directories
+2. Export all tracked unexported documents as `.f3d`/`.f3z` files to the session export directory
+3. Delete cached design files (`.f3d`, `.f3z`) from `W.login` and reset any pending upload queues
 
-Some files may not be deletable while Fusion is still running. AirGap will report which items succeeded and which failed. For any items that could not be deleted, follow the manual procedure below.
+AirGap automatically discovers all user directories within the Fusion cache base. Some files may not be deletable while Fusion is still running. AirGap will report which items succeeded and which failed. For any items that could not be deleted, follow the manual procedure below.
 
 ### Manual Cache Clearing Procedure
 
@@ -57,20 +73,27 @@ After ending an ITAR session and before allowing Fusion to go online:
 
 1. **Close Fusion 360 completely** (not just minimize)
 2. Navigate to the cache directories listed above
-3. Delete the contents of the `W.Login` and `DataCache` folders
-4. Restart Fusion 360
-5. Only then should you allow Fusion to go online
+3. Delete `.f3d` and `.f3z` files from the `W.login` folder in each user directory
+4. Do **not** delete `OfflineCache.xml`, `NsCloudBrowserCache*.dat`, or structural files in `W.login` — Fusion needs these to remain in offline mode
+5. Restart Fusion 360
+6. Only then should you allow Fusion to go online
 
 **WARNING:** Clearing the cache will remove ALL locally cached designs, not just ITAR-controlled ones. Ensure all work is exported before clearing.
 
 ### Cache Clearing Scope and Limitations
 
-AirGap's cache clearing targets the `W.Login` and `DataCache` directories, which contain the primary design data cache. The following locations are **not** covered by AirGap's automatic clearing and may retain residual data:
+AirGap's cache clearing targets design files (`.f3d`, `.f3z`) within `W.login` in each user directory. The following are **intentionally preserved** to maintain offline mode:
+
+- **`NsCloudBrowserCache*.dat`** — Contains Data Panel listings (project names, file names, folder hierarchy) and **embedded design thumbnail images** (base64-encoded PNGs). Fusion requires this file to enter offline mode; without it, Fusion displays an error and forces an online connection. **Important:** These thumbnails are visual previews of designs and may be considered controlled data. However, they pose no upload risk — the browser cache is populated by downloading from Autodesk's servers, and there is no mechanism that uploads this cache back. The risk is limited to data at rest on the local machine. AirGap cannot selectively strip thumbnails from this file without breaking offline mode due to its proprietary binary format. Organizations where thumbnail data at rest is a concern should use full-disk encryption on ITAR workstations.
+- **`OfflineCache.xml`** — Contains licensing, entitlement, and offline timebomb data. Required for Fusion to validate its offline state on startup.
+- **`W.login` structural files** — Cache index, directory structure, and avatar files. Required for Fusion's cache subsystem to function.
+
+The following locations are **not** covered by AirGap's automatic clearing and may retain residual data:
 
 - **OS temp directories** (`%TEMP%` on Windows, `/tmp` on macOS) — may contain Fusion working files
-- **Fusion thumbnail caches** — preview images of designs
 - **OS-level caches** — filesystem caches, virtual memory swap files, and hibernation files
 - **Fusion telemetry queue** — usage analytics data that may be queued for transmission (see Limitations below)
+- **Design thumbnails in browser cache** — embedded in `NsCloudBrowserCache*.dat` (see above); cannot be cleared without breaking offline mode
 
 For maximum data residue reduction, organizations should consider full-disk encryption on ITAR workstations and OS-level secure deletion tools as complementary measures.
 


### PR DESCRIPTION
This pull request adds a new feature to AirGap: automatic clearing of Fusion 360's local cache when ending a session, helping reduce the risk of cached design data syncing to Autodesk servers. The implementation introduces a user setting for enabling this feature, a cache clearing utility, and updates to the session stop workflow and documentation. The most important changes are grouped below.

**Feature: Auto-clear Fusion Cache**

- Added a new user-configurable setting (`auto_clear_cache`) in the settings UI and settings persistence, allowing users to enable automatic cache clearing at session end. 
- Implemented the cache clearing logic in a new module `lib/cache_clearer.py`, which deletes `.f3d` and `.f3z` files and resets upload queues in Fusion’s cache directories, handling errors and partial clears. 
- Updated the session stop command to perform a final autosave and export, then invoke the cache clearer if the setting is enabled, and display detailed results to the user, including files that could not be deleted. 

**Documentation Updates**

- Updated the `README.md` to describe the new cache clearing feature, explain its limitations, and document the new module. 