### PR TITLE
Add handler monitoring and thread-safe logging

### DIFF
--- a/AirGap/config.py
+++ b/AirGap/config.py
@@ -25,8 +25,14 @@ TOOLBAR_PANEL_ID = "AirGapPanel"
 # Custom event for offline polling fallback
 CUSTOM_EVENT_OFFLINE_CHECK = "AirGap_OfflineCheck"
 
+# Custom event for save handler integrity check
+CUSTOM_EVENT_HANDLER_CHECK = "AirGap_HandlerCheck"
+
 # Polling interval for offline mode verification (seconds)
 OFFLINE_CHECK_INTERVAL = 5
+
+# Polling interval for save handler integrity check (seconds)
+HANDLER_CHECK_INTERVAL = 30
 
 # Autosave system
 CUSTOM_EVENT_AUTOSAVE = "AirGap_Autosave"

--- a/AirGap/lib/audit_logger.py
+++ b/AirGap/lib/audit_logger.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import platform
+import threading
 from pathlib import Path
 
 import adsk.core
@@ -52,6 +53,7 @@ class AuditLogger:
         self._prev_hash = GENESIS_HASH
         self._seq = 0
         self._dropped_entries = 0
+        self._lock = threading.Lock()
 
     @classmethod
     def instance(cls):
@@ -84,36 +86,37 @@ class AuditLogger:
         self._session_id = None
 
     def log(self, event_type: str, detail: str, severity: str = "INFO"):
-        entry = {
-            "timestamp": datetime.datetime.now().isoformat(),
-            "session_id": self._session_id or "no_session",
-            "event_type": event_type,
-            "detail": detail,
-            "severity": severity,
-            "user": self._get_user(),
-            "machine": platform.node(),
-            "seq": self._seq,
-            "prev_hash": self._prev_hash,
-        }
-        entry["entry_hash"] = _compute_entry_hash(entry)
-        self._prev_hash = entry["entry_hash"]
-        self._seq += 1
+        with self._lock:
+            entry = {
+                "timestamp": datetime.datetime.now().isoformat(),
+                "session_id": self._session_id or "no_session",
+                "event_type": event_type,
+                "detail": detail,
+                "severity": severity,
+                "user": self._get_user(),
+                "machine": platform.node(),
+                "seq": self._seq,
+                "prev_hash": self._prev_hash,
+            }
+            entry["entry_hash"] = _compute_entry_hash(entry)
+            self._prev_hash = entry["entry_hash"]
+            self._seq += 1
 
-        log_file = self._current_log_file
-        if log_file is None:
+            log_file = self._current_log_file
+            if log_file is None:
+                try:
+                    secure_mkdir(self._log_dir)
+                except OSError:
+                    self._log_dir = Path(config.AUDIT_LOG_DIR)
+                    secure_mkdir(self._log_dir)
+                log_file = self._log_dir / "airgap_unsessioned.jsonl"
+
             try:
-                secure_mkdir(self._log_dir)
+                with open(log_file, "a", encoding="utf-8") as f:
+                    f.write(json.dumps(entry) + "\n")
+                secure_file_permissions(log_file)
             except OSError:
-                self._log_dir = Path(config.AUDIT_LOG_DIR)
-                secure_mkdir(self._log_dir)
-            log_file = self._log_dir / "airgap_unsessioned.jsonl"
-
-        try:
-            with open(log_file, "a", encoding="utf-8") as f:
-                f.write(json.dumps(entry) + "\n")
-            secure_file_permissions(log_file)
-        except OSError:
-            self._dropped_entries += 1
+                self._dropped_entries += 1
 
     def get_current_log_path(self):
         return self._current_log_file

--- a/AirGap/lib/save_interceptor.py
+++ b/AirGap/lib/save_interceptor.py
@@ -1,10 +1,70 @@
+"""Save interceptor with handler hardening.
+
+Fusion drops document event handlers on workspace context switches (e.g. Design
+to Manufacture). A background monitor thread periodically verifies that handlers
+are still registered and reattaches any that were silently removed.
+"""
+
+import json
 import re
+import threading
 from pathlib import Path
 
 import adsk.core
 
+import config
 from lib.audit_logger import AuditLogger
 from lib.session_manager import SessionManager
+
+
+def _try_local_export(doc_name, session):
+    # Attempt auto-export on blocked save; returns (success, path).
+    try:
+        from lib.export_manager import LocalExportManager
+
+        export_dir_root = session.export_directory
+        if not export_dir_root:
+            return False, ""
+
+        clean_name = re.sub(r"( v\d+)+$", "", doc_name).strip() or doc_name
+        safe = "".join(c if c.isalnum() or c in "-_ " else "_" for c in clean_name)
+        export_dir = Path(export_dir_root) / safe
+        export_dir.mkdir(parents=True, exist_ok=True)
+
+        has_xrefs = LocalExportManager.has_external_references()
+        ext = ".f3z" if has_xrefs else ".f3d"
+        export_path = str(export_dir / f"{safe}{ext}")
+
+        if LocalExportManager.export_fusion_archive(export_path):
+            return True, export_path
+    except Exception:
+        pass
+    return False, ""
+
+
+def _show_save_blocked_message(doc_name, exported, export_path):
+    app = adsk.core.Application.get()
+    if exported:
+        app.userInterface.messageBox(
+            f"CLOUD SAVE BLOCKED\n\n"
+            f"Document: {doc_name}\n\n"
+            f"Cloud saves are blocked during AirGap sessions.\n"
+            f"Your work has been exported locally to:\n{export_path}",
+            "AirGap - Save Blocked",
+            adsk.core.MessageBoxButtonTypes.OKButtonType,
+            adsk.core.MessageBoxIconTypes.InformationIconType,
+        )
+    else:
+        app.userInterface.messageBox(
+            f"CLOUD SAVE BLOCKED\n\n"
+            f"Document: {doc_name}\n\n"
+            f"Cloud saves are blocked during AirGap sessions.\n"
+            f'Use the AirGap "Export Locally" button to save '
+            f"files to your local or NAS storage.",
+            "AirGap - Save Blocked",
+            adsk.core.MessageBoxButtonTypes.OKButtonType,
+            adsk.core.MessageBoxIconTypes.CriticalIconType,
+        )
 
 
 class DocumentSavingHandler(adsk.core.DocumentEventHandler):
@@ -45,49 +105,8 @@ class DocumentSavingHandler(adsk.core.DocumentEventHandler):
                 "SAVE_BLOCKED", f"Cloud save blocked for: {doc_name}", "WARNING"
             )
 
-            exported = False
-            export_path = ""
-            try:
-                from lib.export_manager import LocalExportManager
-
-                export_dir_root = session.export_directory
-                if export_dir_root:
-                    clean_name = re.sub(r"( v\d+)+$", "", doc_name).strip() or doc_name
-                    safe = "".join(c if c.isalnum() or c in "-_ " else "_" for c in clean_name)
-                    export_dir = Path(export_dir_root) / safe
-                    export_dir.mkdir(parents=True, exist_ok=True)
-
-                    has_xrefs = LocalExportManager.has_external_references()
-                    ext = ".f3z" if has_xrefs else ".f3d"
-                    export_path = str(export_dir / f"{safe}{ext}")
-
-                    if LocalExportManager.export_fusion_archive(export_path):
-                        exported = True
-            except Exception:
-                pass
-
-            app = adsk.core.Application.get()
-            if exported:
-                app.userInterface.messageBox(
-                    f"CLOUD SAVE BLOCKED\n\n"
-                    f"Document: {doc_name}\n\n"
-                    f"Cloud saves are blocked during AirGap sessions.\n"
-                    f"Your work has been exported locally to:\n{export_path}",
-                    "AirGap - Save Blocked",
-                    adsk.core.MessageBoxButtonTypes.OKButtonType,
-                    adsk.core.MessageBoxIconTypes.InformationIconType,
-                )
-            else:
-                app.userInterface.messageBox(
-                    f"CLOUD SAVE BLOCKED\n\n"
-                    f"Document: {doc_name}\n\n"
-                    f"Cloud saves are blocked during AirGap sessions.\n"
-                    f'Use the AirGap "Export Locally" button to save '
-                    f"files to your local or NAS storage.",
-                    "AirGap - Save Blocked",
-                    adsk.core.MessageBoxButtonTypes.OKButtonType,
-                    adsk.core.MessageBoxIconTypes.CriticalIconType,
-                )
+            exported, export_path = _try_local_export(doc_name, session)
+            _show_save_blocked_message(doc_name, exported, export_path)
         except Exception:
             try:
                 AuditLogger.instance().log(
@@ -151,10 +170,71 @@ class DocumentClosedHandler(adsk.core.DocumentEventHandler):
             pass
 
 
+class HandlerMonitorThread(threading.Thread):
+    def __init__(self, stop_event: threading.Event, app: adsk.core.Application):
+        super().__init__()
+        self.daemon = True
+        self._stop_event = stop_event
+        self._app = app
+
+    def run(self):
+        while not self._stop_event.wait(config.HANDLER_CHECK_INTERVAL):
+            session = SessionManager.instance()
+            if not session.is_protected:
+                continue
+            try:
+                self._app.fireCustomEvent(
+                    config.CUSTOM_EVENT_HANDLER_CHECK, json.dumps({"check": True})
+                )
+            except Exception:
+                try:
+                    AuditLogger.instance().log(
+                        "HANDLER_MONITOR_ERROR",
+                        "Failed to fire handler check event",
+                        "ERROR",
+                    )
+                except Exception:
+                    pass
+        try:
+            AuditLogger.instance().log(
+                "HANDLER_MONITOR_STOPPED",
+                "Handler monitor thread exited",
+                "WARNING",
+            )
+        except Exception:
+            pass
+
+
+class HandlerCheckCustomHandler(adsk.core.CustomEventHandler):
+    def __init__(self, interceptor: "SaveInterceptor"):
+        super().__init__()
+        self._interceptor = interceptor
+
+    def notify(self, args):
+        try:
+            session = SessionManager.instance()
+            if not session.is_protected:
+                return
+            self._interceptor._verify_and_reattach()
+        except Exception:
+            try:
+                AuditLogger.instance().log(
+                    "HANDLER_CHECK_ERROR",
+                    "Handler integrity check failed",
+                    "ERROR",
+                )
+            except Exception:
+                pass
+
+
 class SaveInterceptor:
     def __init__(self):
         self._app = None
         self._handlers = []
+        self._monitor_thread = None
+        self._stop_event = None
+        self._custom_event = None
+        self._check_handler = None
 
     def activate(self, app: adsk.core.Application):
         self._app = app
@@ -169,12 +249,75 @@ class SaveInterceptor:
             event.add(handler)
             self._handlers.append((event, handler))
 
+        self._custom_event = app.registerCustomEvent(config.CUSTOM_EVENT_HANDLER_CHECK)
+        self._check_handler = HandlerCheckCustomHandler(self)
+        self._custom_event.add(self._check_handler)
+
+        self._stop_event = threading.Event()
+        self._monitor_thread = HandlerMonitorThread(self._stop_event, app)
+        self._monitor_thread.start()
+
     def deactivate(self):
+        if self._stop_event:
+            self._stop_event.set()
+            if self._monitor_thread:
+                self._monitor_thread.join(timeout=2)
+            self._stop_event = None
+            self._monitor_thread = None
+
         if not self._app:
             return
+
+        try:
+            if self._custom_event and self._check_handler:
+                self._custom_event.remove(self._check_handler)
+            self._app.unregisterCustomEvent(config.CUSTOM_EVENT_HANDLER_CHECK)
+        except Exception:
+            pass
+
+        self._custom_event = None
+        self._check_handler = None
+
         for event, handler in self._handlers:
             try:
                 event.remove(handler)
             except Exception:
                 pass
         self._handlers.clear()
+
+    def _try_replace_handler(self, index, event, handler_cls):
+        # Create a fresh handler instance after the original failed to re-register.
+        new_handler = handler_cls()
+        try:
+            event.add(new_handler)
+            self._handlers[index] = (event, new_handler)
+            return handler_cls.__name__
+        except Exception:
+            return None
+
+    def _verify_and_reattach(self):
+        if not self._app:
+            return
+
+        reattached = []
+        for i, (event, handler) in enumerate(self._handlers):
+            try:
+                event.remove(handler)
+                event.add(handler)
+            except Exception:
+                name = self._try_replace_handler(i, event, handler.__class__)
+                if name:
+                    reattached.append(name)
+                else:
+                    AuditLogger.instance().log(
+                        "HANDLER_LOST",
+                        f"Failed to reattach handler: {handler.__class__.__name__}",
+                        "CRITICAL",
+                    )
+
+        if reattached:
+            AuditLogger.instance().log(
+                "HANDLER_REATTACHED",
+                f"Re-registered dropped handlers: {', '.join(reattached)}",
+                "WARNING",
+            )


### PR DESCRIPTION
Introduce handler integrity checks and make audit logging thread-safe. Added CUSTOM_EVENT_HANDLER_CHECK and HANDLER_CHECK_INTERVAL to config. Made AuditLogger use a threading.Lock to serialize writes and ensure log file creation/permission handling is done safely. Refactored save interception: factored local export and user-message logic into helpers, added a background HandlerMonitorThread that fires a custom event periodically, and a HandlerCheckCustomHandler that triggers SaveInterceptor._verify_and_reattach to re-register dropped handlers (with replacement fallback). SaveInterceptor now registers/unregisters the custom event and monitor thread during activation/deactivation and logs handler reattach/loss events.