### PR TITLE
Enhancement/session timer

### DIFF
--- a/AirGap/AirGap.py
+++ b/AirGap/AirGap.py
@@ -205,6 +205,7 @@ def stop(context):
                 config.CUSTOM_EVENT_CRASH_RECOVERY,
                 config.CUSTOM_EVENT_UPDATE_CHECK,
                 config.CUSTOM_EVENT_AUTOSAVE,
+                config.CUSTOM_EVENT_TIMER_TICK,
             ):
                 try:
                     _app.unregisterCustomEvent(event_id)

--- a/AirGap/AirGap.py
+++ b/AirGap/AirGap.py
@@ -147,6 +147,11 @@ def run(context):
         if _settings.log_directory:
             AuditLogger.instance().set_log_dir(_settings.log_directory)
 
+        if not _app.isOffLine:
+            from lib.offline_state import OfflineState
+
+            OfflineState.instance().record_online_observation()
+
         restored = handle_crash_recovery(_app, _ui)
 
         ui_components.create_ui(_app)
@@ -178,6 +183,13 @@ def stop(context):
             from lib.autosave_manager import AutosaveManager
 
             AutosaveManager.instance().deactivate()
+        except Exception:
+            pass
+
+        try:
+            from lib.timer_display import TimerDisplay
+
+            TimerDisplay.instance().deactivate()
         except Exception:
             pass
 

--- a/AirGap/commands/__init__.py
+++ b/AirGap/commands/__init__.py
@@ -13,6 +13,7 @@ def register_commands(ui: adsk.core.UserInterface):
     from commands.settings import SettingsCommand
     from commands.start_session import StartSessionCommand
     from commands.stop_session import StopSessionCommand
+    from commands.timer_info import TimerInfoCommand
     from commands.verify_log import VerifyLogCommand
     from commands.view_log import ViewLogCommand
 
@@ -72,6 +73,13 @@ def register_commands(ui: adsk.core.UserInterface):
             "Restore a design from a local autosave.",
             "",
             RestoreAutosaveCommand,
+        ),
+        (
+            config.CMD_TIMER_STATUS,
+            "--",
+            "Session time and offline countdown. Click for details.",
+            "",
+            TimerInfoCommand,
         ),
     ]
 

--- a/AirGap/commands/start_session.py
+++ b/AirGap/commands/start_session.py
@@ -148,6 +148,11 @@ class StartSessionExecuteHandler(adsk.core.CommandEventHandler):
             logger.start_session_log(session_id)
             logger.log("SESSION_START", f"AirGap session initiated. Export dir: {export_dir}")
 
+            if not app.isOffLine:
+                from lib.offline_state import OfflineState
+
+                OfflineState.instance().record_online_observation()
+
             if not _enforcer.activate(app):
                 logger.log("SESSION_ABORT", "Could not enable offline mode", "CRITICAL")
                 session.transition_to(SessionState.UNPROTECTED)
@@ -176,6 +181,10 @@ class StartSessionExecuteHandler(adsk.core.CommandEventHandler):
 
             SessionPersistence.save_state(session)
             update_button_visibility(SessionState.PROTECTED)
+
+            from lib.timer_display import TimerDisplay
+
+            TimerDisplay.instance().activate(app)
 
             from lib.autosave_manager import activate_if_enabled
 

--- a/AirGap/commands/stop_session.py
+++ b/AirGap/commands/stop_session.py
@@ -286,6 +286,13 @@ class StopSessionExecuteHandler(adsk.core.CommandEventHandler):
             except Exception:
                 pass
 
+            try:
+                from lib.timer_display import TimerDisplay
+
+                TimerDisplay.instance().deactivate()
+            except Exception:
+                pass
+
             get_enforcer().deactivate()
             get_interceptor().deactivate()
 

--- a/AirGap/commands/timer_info.py
+++ b/AirGap/commands/timer_info.py
@@ -1,0 +1,89 @@
+import datetime
+
+import adsk.core
+
+from lib.offline_state import OfflineState
+from lib.session_manager import SessionManager
+
+_handlers = []
+
+
+class TimerInfoCommand(adsk.core.CommandCreatedEventHandler):
+    def __init__(self):
+        super().__init__()
+
+    def notify(self, args):
+        try:
+            cmd = args.command
+            execute_handler = _TimerInfoExecuteHandler()
+            cmd.execute.add(execute_handler)
+            _handlers.append(execute_handler)
+        except Exception:
+            pass
+
+
+class _TimerInfoExecuteHandler(adsk.core.CommandEventHandler):
+    def __init__(self):
+        super().__init__()
+
+    def notify(self, args):
+        try:
+            app = adsk.core.Application.get()
+            ui = app.userInterface
+            session = SessionManager.instance()
+            offline_state = OfflineState.instance()
+
+            start_iso = session.session_start_time
+            if start_iso:
+                try:
+                    start = datetime.datetime.fromisoformat(start_iso)
+                    started_str = start.strftime("%Y-%m-%d %H:%M:%S")
+                    delta = datetime.datetime.now() - start
+                    hours, remainder = divmod(int(delta.total_seconds()), 3600)
+                    minutes, seconds = divmod(remainder, 60)
+                    duration_str = f"{hours}h {minutes}m {seconds}s"
+                except (ValueError, TypeError):
+                    started_str = "Unknown"
+                    duration_str = "Unknown"
+            else:
+                started_str = "Unknown"
+                duration_str = "Unknown"
+
+            last_online = offline_state.last_online_time
+            if last_online:
+                try:
+                    lo = datetime.datetime.fromisoformat(last_online)
+                    last_online_str = lo.strftime("%Y-%m-%d %H:%M:%S")
+                except (ValueError, TypeError):
+                    last_online_str = "Unknown"
+            else:
+                last_online_str = "No record available"
+
+            remaining = offline_state.days_remaining()
+            if remaining is not None:
+                if remaining <= 0:
+                    remaining_str = "OVERDUE - Fusion must go online to re-validate license"
+                else:
+                    days = int(remaining)
+                    hours_r = int((remaining - days) * 24)
+                    remaining_str = f"~{days}d {hours_r}h"
+                    if remaining <= 2:
+                        remaining_str += " (WARNING: go online soon)"
+            else:
+                remaining_str = "Unknown - no online observation recorded"
+
+            ui.messageBox(
+                "AIRGAP SESSION TIMER\n\n"
+                f"Session started: {started_str}\n"
+                f"Session duration: {duration_str}\n\n"
+                f"Last known online: {last_online_str}\n"
+                f"Est. offline remaining: {remaining_str}\n\n"
+                "Note: The 14-day estimate is based on the last time "
+                "AirGap observed Fusion online. The actual Fusion license "
+                "timer may differ.",
+                "AirGap - Session Timer",
+                adsk.core.MessageBoxButtonTypes.OKButtonType,
+                adsk.core.MessageBoxIconTypes.InformationIconType,
+            )
+        except Exception:
+            pass

--- a/AirGap/commands/timer_info.py
+++ b/AirGap/commands/timer_info.py
@@ -4,6 +4,7 @@ import adsk.core
 
 from lib.offline_state import OfflineState
 from lib.session_manager import SessionManager
+from lib.timer_display import format_session_elapsed
 
 _handlers = []
 
@@ -36,18 +37,14 @@ class _TimerInfoExecuteHandler(adsk.core.CommandEventHandler):
             start_iso = session.session_start_time
             if start_iso:
                 try:
-                    start = datetime.datetime.fromisoformat(start_iso)
-                    started_str = start.strftime("%Y-%m-%d %H:%M:%S")
-                    delta = datetime.datetime.now() - start
-                    hours, remainder = divmod(int(delta.total_seconds()), 3600)
-                    minutes, seconds = divmod(remainder, 60)
-                    duration_str = f"{hours}h {minutes}m {seconds}s"
+                    started_str = datetime.datetime.fromisoformat(start_iso).strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
                 except (ValueError, TypeError):
                     started_str = "Unknown"
-                    duration_str = "Unknown"
             else:
                 started_str = "Unknown"
-                duration_str = "Unknown"
+            duration_str = format_session_elapsed(start_iso, include_seconds=True)
 
             last_online = offline_state.last_online_time
             if last_online:

--- a/AirGap/config.py
+++ b/AirGap/config.py
@@ -41,6 +41,12 @@ DEFAULT_AUTOSAVE_MAX_VERSIONS = 3
 AUTOSAVE_SUBDIR = ".airgap_autosave"
 AUTOSAVE_CONSECUTIVE_FAILURE_LIMIT = 3
 
+# Timer display
+CMD_TIMER_STATUS = "airgap_timer_status"
+CUSTOM_EVENT_TIMER_TICK = "AirGap_TimerTick"
+TIMER_TICK_INTERVAL = 60
+FUSION_OFFLINE_LICENSE_DAYS = 14
+
 # Custom events for startup subsystems
 CUSTOM_EVENT_AUTO_START = "AirGap_AutoStart"
 CUSTOM_EVENT_CRASH_RECOVERY = "AirGap_CrashRecoveryComplete"
@@ -63,6 +69,7 @@ DEFAULT_EXPORT_DIR = Path.home() / "AirGap_Exports"
 AUDIT_LOG_DIR = _BASE_DIR / "logs"
 SESSION_STATE_FILE = _BASE_DIR / "session_state.json"
 SETTINGS_FILE = _BASE_DIR / "settings.json"
+OFFLINE_STATE_FILE = _BASE_DIR / "offline_state.json"
 
 # Fusion 360 cache base directories
 if sys.platform == "win32":

--- a/AirGap/lib/auto_start.py
+++ b/AirGap/lib/auto_start.py
@@ -79,6 +79,13 @@ def _activate_session(app, session, session_id, export_dir, start_time):
     ui_components.update_button_visibility(SessionState.PROTECTED)
 
     try:
+        from lib.timer_display import TimerDisplay
+
+        TimerDisplay.instance().activate(app)
+    except Exception:
+        pass
+
+    try:
         from lib.autosave_manager import activate_if_enabled
 
         activate_if_enabled(app, session_id, export_dir)
@@ -102,6 +109,11 @@ class _AutoStartHandler(adsk.core.CustomEventHandler):
                 return
 
             settings = Settings.instance()
+
+            if not app.isOffLine:
+                from lib.offline_state import OfflineState
+
+                OfflineState.instance().record_online_observation()
 
             app.isOffLine = True
             AuditLogger.instance().log(

--- a/AirGap/lib/crash_recovery.py
+++ b/AirGap/lib/crash_recovery.py
@@ -162,6 +162,13 @@ class _CrashRecoveryCompleteHandler(adsk.core.CustomEventHandler):
             logger.log("CRASH_RECOVERY", "Offline enforcement activated after Fusion startup")
 
             try:
+                from lib.timer_display import TimerDisplay
+
+                TimerDisplay.instance().activate(app)
+            except Exception:
+                pass
+
+            try:
                 from lib.autosave_manager import activate_if_enabled
 
                 activate_if_enabled(app, session.session_id, session.export_directory)

--- a/AirGap/lib/offline_state.py
+++ b/AirGap/lib/offline_state.py
@@ -1,0 +1,69 @@
+import datetime
+import json
+import uuid
+from pathlib import Path
+from typing import Optional
+
+import config
+from lib.integrity import is_envelope, unwrap_and_verify, wrap_with_checksum
+from lib.path_validation import secure_file_permissions, secure_mkdir
+
+
+class OfflineState:
+    _instance: Optional["OfflineState"] = None
+
+    def __init__(self):
+        self._last_online_time: str | None = None
+        self._load()
+
+    @classmethod
+    def instance(cls) -> "OfflineState":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @property
+    def last_online_time(self) -> str | None:
+        return self._last_online_time
+
+    def record_online_observation(self):
+        self._last_online_time = datetime.datetime.now().isoformat()
+        self._save()
+
+    def days_remaining(self) -> float | None:
+        if not self._last_online_time:
+            return None
+        try:
+            last_online = datetime.datetime.fromisoformat(self._last_online_time)
+            elapsed = datetime.datetime.now() - last_online
+            return config.FUSION_OFFLINE_LICENSE_DAYS - elapsed.total_seconds() / 86400
+        except (ValueError, TypeError):
+            return None
+
+    def _load(self):
+        state_file = Path(config.OFFLINE_STATE_FILE)
+        if not state_file.exists():
+            return
+        try:
+            with open(state_file, encoding="utf-8") as f:
+                raw = json.load(f)
+            if is_envelope(raw):
+                payload = unwrap_and_verify(raw)
+                if payload is None:
+                    return
+            else:
+                payload = raw
+            self._last_online_time = payload.get("last_online_time")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    def _save(self):
+        state_file = Path(config.OFFLINE_STATE_FILE)
+        secure_mkdir(state_file.parent)
+        data = {"last_online_time": self._last_online_time}
+        envelope = wrap_with_checksum(data)
+        tmp_file = state_file.with_suffix(f".tmp.{uuid.uuid4().hex[:8]}")
+        with open(tmp_file, "w", encoding="utf-8") as f:
+            json.dump(envelope, f, indent=2)
+        tmp_file.replace(state_file)
+        secure_file_permissions(state_file)

--- a/AirGap/lib/offline_state.py
+++ b/AirGap/lib/offline_state.py
@@ -29,6 +29,15 @@ class OfflineState:
     def record_online_observation(self):
         self._last_online_time = datetime.datetime.now().isoformat()
         self._save()
+        try:
+            from lib.audit_logger import AuditLogger
+
+            AuditLogger.instance().log(
+                "ONLINE_OBSERVATION",
+                "Fusion observed online; offline license countdown baseline updated",
+            )
+        except Exception:
+            pass
 
     def days_remaining(self) -> float | None:
         if not self._last_online_time:
@@ -50,6 +59,16 @@ class OfflineState:
             if is_envelope(raw):
                 payload = unwrap_and_verify(raw)
                 if payload is None:
+                    try:
+                        from lib.audit_logger import AuditLogger
+
+                        AuditLogger.instance().log(
+                            "INTEGRITY_VIOLATION",
+                            "Offline state file failed checksum verification; file rejected",
+                            "CRITICAL",
+                        )
+                    except Exception:
+                        pass
                     return
             else:
                 payload = raw

--- a/AirGap/lib/persistence.py
+++ b/AirGap/lib/persistence.py
@@ -19,6 +19,7 @@ class SessionPersistence:
             "tracked_documents": list(session.tracked_documents),
             "exported_documents": list(session.exported_documents),
             "export_directory": session.export_directory,
+            "session_start_time": session.session_start_time,
             "timestamp": datetime.datetime.now().isoformat(),
             "pid": os.getpid(),
         }
@@ -87,3 +88,4 @@ class SessionPersistence:
         session._tracked_documents = set(state_data.get("tracked_documents", []))
         session._exported_documents = set(state_data.get("exported_documents", []))
         session._export_directory = state_data.get("export_directory", "")
+        session._session_start_time = state_data.get("session_start_time")

--- a/AirGap/lib/timer_display.py
+++ b/AirGap/lib/timer_display.py
@@ -9,20 +9,22 @@ from lib.offline_state import OfflineState
 from lib.session_manager import SessionManager
 
 
-def _format_session_elapsed(start_iso: str | None) -> str:
+def format_session_elapsed(start_iso: str | None, include_seconds: bool = False) -> str:
     if not start_iso:
         return "--"
     try:
         start = datetime.datetime.fromisoformat(start_iso)
         delta = datetime.datetime.now() - start
         hours, remainder = divmod(int(delta.total_seconds()), 3600)
-        minutes = remainder // 60
+        minutes, seconds = divmod(remainder, 60)
+        if include_seconds:
+            return f"{hours}h {minutes}m {seconds}s"
         return f"{hours}h {minutes}m"
     except (ValueError, TypeError):
         return "--"
 
 
-def _format_countdown(days_remaining: float | None) -> str:
+def format_countdown(days_remaining: float | None) -> str:
     if days_remaining is None:
         return "14d limit: unknown"
     if days_remaining <= 0:
@@ -37,8 +39,8 @@ def _format_countdown(days_remaining: float | None) -> str:
 
 def _build_label() -> str:
     session = SessionManager.instance()
-    elapsed = _format_session_elapsed(session.session_start_time)
-    countdown = _format_countdown(OfflineState.instance().days_remaining())
+    elapsed = format_session_elapsed(session.session_start_time)
+    countdown = format_countdown(OfflineState.instance().days_remaining())
     return f"{elapsed} | {countdown}"
 
 
@@ -80,6 +82,18 @@ def _reset_panel_name(app: adsk.core.Application):
         pass
 
 
+class _TimerTickHandler(adsk.core.CustomEventHandler):
+    def __init__(self):
+        super().__init__()
+
+    def notify(self, args):
+        try:
+            app = adsk.core.Application.get()
+            _update_all(app)
+        except Exception:
+            pass
+
+
 class TimerTickThread(threading.Thread):
     def __init__(self, stop_event: threading.Event, app: adsk.core.Application):
         super().__init__()
@@ -90,7 +104,7 @@ class TimerTickThread(threading.Thread):
     def run(self):
         while not self._stop_event.wait(config.TIMER_TICK_INTERVAL):
             try:
-                _update_all(self._app)
+                self._app.fireCustomEvent(config.CUSTOM_EVENT_TIMER_TICK, "")
             except Exception:
                 pass
 
@@ -102,6 +116,8 @@ class TimerDisplay:
         self._app: adsk.core.Application | None = None
         self._thread: TimerTickThread | None = None
         self._stop_event: threading.Event | None = None
+        self._custom_event = None
+        self._handlers = []
 
     @classmethod
     def instance(cls) -> "TimerDisplay":
@@ -119,6 +135,11 @@ class TimerDisplay:
 
         self._app = app
 
+        self._custom_event = app.registerCustomEvent(config.CUSTOM_EVENT_TIMER_TICK)
+        handler = _TimerTickHandler()
+        self._custom_event.add(handler)
+        self._handlers.append(handler)
+
         self._stop_event = threading.Event()
         self._thread = TimerTickThread(self._stop_event, app)
         self._thread.start()
@@ -130,6 +151,15 @@ class TimerDisplay:
             self._stop_event.set()
             self._stop_event = None
             self._thread = None
+
+        if self._custom_event:
+            try:
+                app = adsk.core.Application.get()
+                app.unregisterCustomEvent(config.CUSTOM_EVENT_TIMER_TICK)
+            except Exception:
+                pass
+            self._custom_event = None
+            self._handlers.clear()
 
         try:
             app = adsk.core.Application.get()

--- a/AirGap/lib/timer_display.py
+++ b/AirGap/lib/timer_display.py
@@ -1,0 +1,142 @@
+import datetime
+import threading
+from typing import Optional
+
+import adsk.core
+
+import config
+from lib.offline_state import OfflineState
+from lib.session_manager import SessionManager
+
+
+def _format_session_elapsed(start_iso: str | None) -> str:
+    if not start_iso:
+        return "--"
+    try:
+        start = datetime.datetime.fromisoformat(start_iso)
+        delta = datetime.datetime.now() - start
+        hours, remainder = divmod(int(delta.total_seconds()), 3600)
+        minutes = remainder // 60
+        return f"{hours}h {minutes}m"
+    except (ValueError, TypeError):
+        return "--"
+
+
+def _format_countdown(days_remaining: float | None) -> str:
+    if days_remaining is None:
+        return "14d limit: unknown"
+    if days_remaining <= 0:
+        return "! OVERDUE"
+    days = int(days_remaining)
+    hours = int((days_remaining - days) * 24)
+    label = f"~{days}d {hours}h left"
+    if days_remaining <= 2:
+        label = f"! {label}"
+    return label
+
+
+def _build_label() -> str:
+    session = SessionManager.instance()
+    elapsed = _format_session_elapsed(session.session_start_time)
+    countdown = _format_countdown(OfflineState.instance().days_remaining())
+    return f"{elapsed} | {countdown}"
+
+
+def _update_all(app: adsk.core.Application):
+    label = _build_label()
+    try:
+        ui = app.userInterface
+        cmd_def = ui.commandDefinitions.itemById(config.CMD_TIMER_STATUS)
+        if cmd_def:
+            cmd_def.name = label
+        for ws_id in config.TARGET_WORKSPACES:
+            ws = ui.workspaces.itemById(ws_id)
+            if ws is None:
+                continue
+            tab = ws.toolbarTabs.itemById(config.TOOLBAR_TAB_ID)
+            if tab is None:
+                continue
+            panel = tab.toolbarPanels.itemById(config.TOOLBAR_PANEL_ID)
+            if panel:
+                panel.name = label
+    except Exception:
+        pass
+
+
+def _reset_panel_name(app: adsk.core.Application):
+    try:
+        ui = app.userInterface
+        for ws_id in config.TARGET_WORKSPACES:
+            ws = ui.workspaces.itemById(ws_id)
+            if ws is None:
+                continue
+            tab = ws.toolbarTabs.itemById(config.TOOLBAR_TAB_ID)
+            if tab is None:
+                continue
+            panel = tab.toolbarPanels.itemById(config.TOOLBAR_PANEL_ID)
+            if panel:
+                panel.name = "Export Control"
+    except Exception:
+        pass
+
+
+class TimerTickThread(threading.Thread):
+    def __init__(self, stop_event: threading.Event, app: adsk.core.Application):
+        super().__init__()
+        self.daemon = True
+        self._stop_event = stop_event
+        self._app = app
+
+    def run(self):
+        while not self._stop_event.wait(config.TIMER_TICK_INTERVAL):
+            try:
+                _update_all(self._app)
+            except Exception:
+                pass
+
+
+class TimerDisplay:
+    _instance: Optional["TimerDisplay"] = None
+
+    def __init__(self):
+        self._app: adsk.core.Application | None = None
+        self._thread: TimerTickThread | None = None
+        self._stop_event: threading.Event | None = None
+
+    @classmethod
+    def instance(cls) -> "TimerDisplay":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @property
+    def is_active(self) -> bool:
+        return self._stop_event is not None and not self._stop_event.is_set()
+
+    def activate(self, app: adsk.core.Application):
+        if self.is_active:
+            self.deactivate()
+
+        self._app = app
+
+        self._stop_event = threading.Event()
+        self._thread = TimerTickThread(self._stop_event, app)
+        self._thread.start()
+
+        _update_all(app)
+
+    def deactivate(self):
+        if self._stop_event:
+            self._stop_event.set()
+            self._stop_event = None
+            self._thread = None
+
+        try:
+            app = adsk.core.Application.get()
+            ui = app.userInterface
+            cmd_def = ui.commandDefinitions.itemById(config.CMD_TIMER_STATUS)
+            if cmd_def:
+                cmd_def.name = "--"
+            _reset_panel_name(app)
+        except Exception:
+            pass

--- a/AirGap/lib/ui_components.py
+++ b/AirGap/lib/ui_components.py
@@ -11,6 +11,7 @@ _VISIBLE_WHEN_PROTECTED = {
     config.CMD_STOP_SESSION,
     config.CMD_EXPORT_LOCAL,
     config.CMD_RESTORE_AUTOSAVE,
+    config.CMD_TIMER_STATUS,
 }
 _VISIBLE_WHEN_UNPROTECTED = {config.CMD_START_SESSION}
 
@@ -18,12 +19,15 @@ _panels_created = []
 _tabs_created = []
 
 
+_ALWAYS_PROMOTED_WHEN_PROTECTED = {config.CMD_TIMER_STATUS}
+
+
 def _apply_control_visibility(ctrl, cmd_id, is_protected, set_promoted_default=False):
     if cmd_id in _VISIBLE_WHEN_PROTECTED:
         ctrl.isVisible = is_protected
         ctrl.isPromoted = is_protected
         if set_promoted_default:
-            ctrl.isPromotedByDefault = False
+            ctrl.isPromotedByDefault = cmd_id in _ALWAYS_PROMOTED_WHEN_PROTECTED
     elif cmd_id in _VISIBLE_WHEN_UNPROTECTED:
         ctrl.isVisible = not is_protected
         ctrl.isPromoted = not is_protected
@@ -66,6 +70,7 @@ def create_ui(app: adsk.core.Application):
             config.CMD_SETTINGS,
             config.CMD_CHECK_UPDATE,
             config.CMD_RESTORE_AUTOSAVE,
+            config.CMD_TIMER_STATUS,
         ]
         for cmd_id in cmd_ids:
             ctrl = panel.controls.itemById(cmd_id)

--- a/tests/test_offline_state.py
+++ b/tests/test_offline_state.py
@@ -1,0 +1,103 @@
+import datetime
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import config
+from lib.integrity import wrap_with_checksum
+from lib.offline_state import OfflineState
+
+
+class TestOfflineState(unittest.TestCase):
+    def setUp(self):
+        OfflineState._instance = None
+        self._tmp_dir = tempfile.mkdtemp()
+        self._state_file = Path(self._tmp_dir) / "offline_state.json"
+        self._orig = config.OFFLINE_STATE_FILE
+        config.OFFLINE_STATE_FILE = self._state_file
+
+    def tearDown(self):
+        config.OFFLINE_STATE_FILE = self._orig
+        OfflineState._instance = None
+        shutil.rmtree(self._tmp_dir, ignore_errors=True)
+
+    def test_singleton(self):
+        a = OfflineState.instance()
+        b = OfflineState.instance()
+        self.assertIs(a, b)
+
+    def test_initial_state_has_no_online_time(self):
+        state = OfflineState.instance()
+        self.assertIsNone(state.last_online_time)
+
+    def test_days_remaining_none_when_no_observation(self):
+        state = OfflineState.instance()
+        self.assertIsNone(state.days_remaining())
+
+    def test_record_online_observation(self):
+        state = OfflineState.instance()
+        state.record_online_observation()
+        self.assertIsNotNone(state.last_online_time)
+        datetime.datetime.fromisoformat(state.last_online_time)
+
+    def test_days_remaining_calculation(self):
+        state = OfflineState.instance()
+        two_days_ago = datetime.datetime.now() - datetime.timedelta(days=2)
+        state._last_online_time = two_days_ago.isoformat()
+        remaining = state.days_remaining()
+        self.assertIsNotNone(remaining)
+        self.assertAlmostEqual(remaining, 12.0, delta=0.1)
+
+    def test_days_remaining_overdue(self):
+        state = OfflineState.instance()
+        twenty_days_ago = datetime.datetime.now() - datetime.timedelta(days=20)
+        state._last_online_time = twenty_days_ago.isoformat()
+        remaining = state.days_remaining()
+        self.assertIsNotNone(remaining)
+        self.assertLess(remaining, 0)
+
+    def test_persistence_round_trip(self):
+        state = OfflineState.instance()
+        state.record_online_observation()
+        saved_time = state.last_online_time
+
+        OfflineState._instance = None
+        state2 = OfflineState.instance()
+        self.assertEqual(state2.last_online_time, saved_time)
+
+    def test_tampered_file_ignored(self):
+        data = {"last_online_time": "2025-01-01T00:00:00"}
+        envelope = wrap_with_checksum(data)
+        envelope["payload"]["last_online_time"] = "2025-12-31T23:59:59"
+        with open(self._state_file, "w", encoding="utf-8") as f:
+            json.dump(envelope, f)
+
+        state = OfflineState.instance()
+        self.assertIsNone(state.last_online_time)
+
+    def test_legacy_file_without_envelope(self):
+        raw = {"last_online_time": "2025-06-15T10:30:00"}
+        with open(self._state_file, "w", encoding="utf-8") as f:
+            json.dump(raw, f)
+
+        state = OfflineState.instance()
+        self.assertEqual(state.last_online_time, "2025-06-15T10:30:00")
+
+    def test_corrupted_json_ignored(self):
+        with open(self._state_file, "w", encoding="utf-8") as f:
+            f.write("{not valid json")
+
+        state = OfflineState.instance()
+        self.assertIsNone(state.last_online_time)
+
+    def test_save_creates_file(self):
+        state = OfflineState.instance()
+        self.assertFalse(self._state_file.exists())
+        state.record_online_observation()
+        self.assertTrue(self._state_file.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timer_display.py
+++ b/tests/test_timer_display.py
@@ -1,0 +1,65 @@
+import datetime
+import unittest
+
+from lib.timer_display import format_countdown, format_session_elapsed
+
+
+class TestFormatSessionElapsed(unittest.TestCase):
+    def test_none_returns_dash(self):
+        self.assertEqual(format_session_elapsed(None), "--")
+
+    def test_empty_string_returns_dash(self):
+        self.assertEqual(format_session_elapsed(""), "--")
+
+    def test_invalid_string_returns_dash(self):
+        self.assertEqual(format_session_elapsed("not-a-date"), "--")
+
+    def test_known_elapsed(self):
+        start = datetime.datetime.now() - datetime.timedelta(hours=2, minutes=15, seconds=30)
+        result = format_session_elapsed(start.isoformat())
+        self.assertEqual(result, "2h 15m")
+
+    def test_known_elapsed_with_seconds(self):
+        start = datetime.datetime.now() - datetime.timedelta(hours=2, minutes=15, seconds=30)
+        result = format_session_elapsed(start.isoformat(), include_seconds=True)
+        self.assertEqual(result, "2h 15m 30s")
+
+    def test_zero_elapsed(self):
+        start = datetime.datetime.now()
+        result = format_session_elapsed(start.isoformat())
+        self.assertEqual(result, "0h 0m")
+
+    def test_large_elapsed(self):
+        start = datetime.datetime.now() - datetime.timedelta(days=3, hours=5)
+        result = format_session_elapsed(start.isoformat())
+        self.assertEqual(result, "77h 0m")
+
+
+class TestFormatCountdown(unittest.TestCase):
+    def test_none_returns_unknown(self):
+        self.assertEqual(format_countdown(None), "14d limit: unknown")
+
+    def test_zero_returns_overdue(self):
+        self.assertEqual(format_countdown(0), "! OVERDUE")
+
+    def test_negative_returns_overdue(self):
+        self.assertEqual(format_countdown(-3.5), "! OVERDUE")
+
+    def test_normal_remaining(self):
+        self.assertEqual(format_countdown(10.5), "~10d 12h left")
+
+    def test_warning_threshold(self):
+        result = format_countdown(1.5)
+        self.assertEqual(result, "! ~1d 12h left")
+
+    def test_exactly_two_days_triggers_warning(self):
+        result = format_countdown(2.0)
+        self.assertTrue(result.startswith("!"))
+
+    def test_above_two_days_no_warning(self):
+        result = format_countdown(2.1)
+        self.assertFalse(result.startswith("!"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new session timer and offline license countdown feature to the AirGap add-in, enhancing user visibility into session duration and license status. It adds a dynamic timer display to the UI, tracks the last observed online time for offline license enforcement, and provides a new command for users to view detailed timing and license information. The implementation involves new modules, UI integration, persistent state management, and periodic updates.

**Session Timer and Offline License Countdown Feature**

*Core functionality and state management:*
- Added the `OfflineState` class (`lib/offline_state.py`) to persist and track the last time Fusion was observed online, calculate days remaining on the offline license, and handle secure storage and integrity checks. This state is updated on relevant online observations throughout the app.
- Updated session persistence to store and restore the session start time, allowing accurate session duration calculations. 

*UI integration and timer display:*
- Introduced the `TimerDisplay` class (`lib/timer_display.py`) to manage a periodic timer that updates the UI with session duration and offline countdown, including a thread for timer ticks and event-based UI updates.
- Added a new `TimerInfoCommand` (`commands/timer_info.py`) and registered it in the UI, providing a button that shows session timing and offline countdown details in a message box.
- Ensured the timer display is activated and deactivated at appropriate times, such as session start, stop, crash recovery, and auto-start.

*Configuration and UI enhancements:*
- Added new configuration constants for timer events, intervals, and offline license duration in `config.py`, and included the timer command in protected UI states.
- Updated UI logic to always promote the timer status button when protected and to update panel/command names with timing info.

*Online observation tracking:*
- Inserted logic to record online observations in key workflow entry points, ensuring the offline license countdown is reset whenever Fusion is detected online. 

*Event handling:*
- Registered and unregistered a new custom event for timer ticks (`CUSTOM_EVENT_TIMER_TICK`), ensuring clean event management during activation and deactivation.